### PR TITLE
remove unused intermediate assignments

### DIFF
--- a/plugins/modules/icinga_command.py
+++ b/plugins/modules/icinga_command.py
@@ -233,33 +233,23 @@ def main():
         supports_check_mode=True
     )
 
-    state = module.params["state"]
-    object_name = module.params["object_name"]
-    imports = module.params["imports"]
-    disabled = module.params["disabled"]
-    vars = module.params["vars"]
-    command = module.params["command"]
-    command_type = module.params["command_type"]
-    timeout = module.params["timeout"]
-    zone = module.params["zone"]
     # typ von arguments ist eigentlich dict, also ohne Angabe = {}
     # die director API schickt hier aber ein leeres Array zurueck wenn nichts definiert
     # daher ueberschreiben, damit der diff besser funktioniert
     if not module.params["arguments"]:
         module.params["arguments"] = []
-    arguments = module.params["arguments"]
 
     data = {
-        'object_name': object_name,
+        'object_name': module.params["object_name"],
         'object_type': "object",
-        'imports': imports,
-        'disabled': disabled,
-        'vars': vars,
-        'command': command,
-        'methods_execute': command_type,
-        'timeout': timeout,
-        'zone': zone,
-        'arguments': arguments,
+        'imports': module.params["imports"],
+        'disabled': module.params["disabled"],
+        'vars': module.params["vars"],
+        'command': module.params["command"],
+        'methods_execute': module.params["command_type"],
+        'timeout': module.params["timeout"],
+        'zone': module.params["zone"],
+        'arguments': module.params["arguments"],
     }
 
     try:
@@ -267,8 +257,8 @@ def main():
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % e)
 
-    changed, diff = icinga_object.update(state)
-    module.exit_json(changed=changed, object_name=object_name, data=icinga_object.data, diff=diff)
+    changed, diff = icinga_object.update(module.params["state"])
+    module.exit_json(changed=changed, object_name=module.params["object_name"], data=icinga_object.data, diff=diff)
 
 
 # import module snippets

--- a/plugins/modules/icinga_command.py
+++ b/plugins/modules/icinga_command.py
@@ -35,7 +35,7 @@ author: Sebastian Gumprich
 options:
   url:
     description:
-      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+      - HTTP or HTTPS URL in the form (http|https://[user[:pass]]@host.domain[:port]/path
     required: true
     type: str
   use_proxy:

--- a/plugins/modules/icinga_command_template.py
+++ b/plugins/modules/icinga_command_template.py
@@ -233,33 +233,23 @@ def main():
         supports_check_mode=True
     )
 
-    state = module.params["state"]
-    object_name = module.params["object_name"]
-    imports = module.params["imports"]
-    disabled = module.params["disabled"]
-    vars = module.params["vars"]
-    command = module.params["command"]
-    command_type = module.params["command_type"]
-    timeout = module.params["timeout"]
-    zone = module.params["zone"]
     # `arguments` is of type dict, default should be {}
     # however, the director api returns [] when no `arguments` are set, making the diff seem changed
     # therefore set the default to [] as well to get a clean diff output
     if not module.params["arguments"]:
         module.params["arguments"] = []
-    arguments = module.params["arguments"]
 
     data = {
-        'object_name': object_name,
+        'object_name': module.params["object_name"],
         'object_type': "template",
-        'imports': imports,
-        'disabled': disabled,
-        'vars': vars,
-        'command': command,
-        'methods_execute': command_type,
-        'timeout': timeout,
-        'zone': zone,
-        'arguments': arguments,
+        'imports': module.params["imports"],
+        'disabled': module.params["disabled"],
+        'vars': module.params["vars"],
+        'command': module.params["command"],
+        'methods_execute': module.params["command_type"],
+        'timeout': module.params["timeout"],
+        'zone': module.params["zone"],
+        'arguments': module.params["arguments"],
     }
 
     try:
@@ -267,8 +257,8 @@ def main():
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % e)
 
-    changed, diff = icinga_object.update(state)
-    module.exit_json(changed=changed, object_name=object_name, data=icinga_object.data, diff=diff)
+    changed, diff = icinga_object.update(module.params["state"])
+    module.exit_json(changed=changed, object_name=module.params["object_name"], data=icinga_object.data, diff=diff)
 
 
 # import module snippets

--- a/plugins/modules/icinga_command_template.py
+++ b/plugins/modules/icinga_command_template.py
@@ -35,7 +35,7 @@ author: "Lars Krahl (@mmslkr)"
 options:
   url:
     description:
-      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+      - HTTP or HTTPS URL in the form (http|https://[user[:pass]]@host.domain[:port]/path
     required: true
     type: str
   use_proxy:

--- a/plugins/modules/icinga_host.py
+++ b/plugins/modules/icinga_host.py
@@ -36,7 +36,7 @@ author:
 options:
   url:
     description:
-      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+      - HTTP or HTTPS URL in the form (http|https://[user[:pass]]@host.domain[:port]/path
     required: true
     type: str
   use_proxy:

--- a/plugins/modules/icinga_host.py
+++ b/plugins/modules/icinga_host.py
@@ -192,26 +192,16 @@ def main():
         supports_check_mode=True
     )
 
-    state = module.params["state"]
-    object_name = module.params["object_name"]
-    display_name = module.params["display_name"]
-    groups = module.params["groups"]
-    imports = module.params["imports"]
-    disabled = module.params["disabled"]
-    address = module.params["address"]
-    zone = module.params["zone"]
-    vars = module.params["vars"]
-
     data = {
-        'object_name': object_name,
+        'object_name': module.params["object_name"],
         'object_type': "object",
-        'display_name': display_name,
-        'groups': groups,
-        'imports': imports,
-        'disabled': disabled,
-        'address': address,
-        'zone': zone,
-        'vars': vars,
+        'display_name': module.params["display_name"],
+        'groups': module.params["groups"],
+        'imports': module.params["imports"],
+        'disabled': module.params["disabled"],
+        'address': module.params["address"],
+        'zone': module.params["zone"],
+        'vars': module.params["vars"],
     }
 
     try:
@@ -219,8 +209,8 @@ def main():
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % e)
 
-    changed, diff = icinga_object.update(state)
-    module.exit_json(changed=changed, object_name=object_name, data=icinga_object.data, diff=diff)
+    changed, diff = icinga_object.update(module.params["state"])
+    module.exit_json(changed=changed, object_name=module.params["object_name"], data=icinga_object.data, diff=diff)
 
 
 # import module snippets

--- a/plugins/modules/icinga_hostgroup.py
+++ b/plugins/modules/icinga_hostgroup.py
@@ -35,7 +35,7 @@ author: "Sebastian Gumprich"
 options:
   url:
     description:
-      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+      - HTTP or HTTPS URL in the form (http|https://[user[:pass]]@host.domain[:port]/path
     required: true
     type: str
   use_proxy:

--- a/plugins/modules/icinga_hostgroup.py
+++ b/plugins/modules/icinga_hostgroup.py
@@ -146,16 +146,11 @@ def main():
         supports_check_mode=True
     )
 
-    state = module.params["state"]
-    object_name = module.params["object_name"]
-    display_name = module.params["display_name"]
-    assign_filter = module.params["assign_filter"]
-
     data = {
-        'object_name': object_name,
+        'object_name': module.params["object_name"],
         'object_type': "object",
-        'display_name': display_name,
-        'assign_filter': assign_filter,
+        'display_name': module.params["display_name"],
+        'assign_filter': module.params["assign_filter"],
     }
 
     try:
@@ -163,8 +158,8 @@ def main():
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % e)
 
-    changed, diff = icinga_object.update(state)
-    module.exit_json(changed=changed, object_name=object_name, data=icinga_object.data, diff=diff)
+    changed, diff = icinga_object.update(module.params["state"])
+    module.exit_json(changed=changed, object_name=module.params["object_name"], data=icinga_object.data, diff=diff)
 
 
 # import module snippets

--- a/plugins/modules/icinga_notification.py
+++ b/plugins/modules/icinga_notification.py
@@ -178,24 +178,15 @@ def main():
         supports_check_mode=True
     )
 
-    state = module.params["state"]
-    object_name = module.params["object_name"]
-    imports = module.params["imports"]
-    apply_to = module.params["apply_to"]
-    assign_filter = module.params["assign_filter"]
-    notification_interval = module.params["notification_interval"]
-    types = module.params["types"]
-    users = module.params["users"]
-
     data = {
-        'object_name': object_name,
+        'object_name': module.params["object_name"],
         'object_type': "apply",
-        'imports': imports,
-        'apply_to': apply_to,
-        'assign_filter': assign_filter,
-        'notification_interval': notification_interval,
-        'types': types,
-        'users': users,
+        'imports': module.params["imports"],
+        'apply_to': module.params["apply_to"],
+        'assign_filter': module.params["assign_filter"],
+        'notification_interval': module.params["notification_interval"],
+        'types': module.params["types"],
+        'users': module.params["users"],
     }
 
     try:
@@ -203,8 +194,8 @@ def main():
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % e)
 
-    changed, diff = icinga_object.update(state)
-    module.exit_json(changed=changed, object_name=object_name, data=icinga_object.data, diff=diff)
+    changed, diff = icinga_object.update(module.params["state"])
+    module.exit_json(changed=changed, object_name=module.params["object_name"], data=icinga_object.data, diff=diff)
 
 
 # import module snippets

--- a/plugins/modules/icinga_notification.py
+++ b/plugins/modules/icinga_notification.py
@@ -35,7 +35,7 @@ author: "Sebastian Gumprich"
 options:
   url:
     description:
-      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+      - HTTP or HTTPS URL in the form (http|https://[user[:pass]]@host.domain[:port]/path
     required: true
     type: str
   use_proxy:

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -232,28 +232,17 @@ def main():
         supports_check_mode=True
     )
 
-    state = module.params["state"]
-    object_name = module.params["object_name"]
-    display_name = module.params["display_name"]
-    apply_for = module.params["apply_for"]
-    assign_filter = module.params["assign_filter"]
-    imports = module.params["imports"]
-    groups = module.params["groups"]
-    vars = module.params["vars"]
-    notes = module.params["notes"]
-    notes_url = module.params["notes_url"]
-
     data = {
-        'object_name': object_name,
-        'display_name': display_name,
+        'object_name': module.params["object_name"],
+        'display_name': module.params["display_name"],
         'object_type': "apply",
-        'apply_for': apply_for,
-        'assign_filter': assign_filter,
-        'imports': imports,
-        'groups': groups,
-        'vars': vars,
-        'notes': notes,
-        'notes_url': notes_url,
+        'apply_for': module.params["apply_for"],
+        'assign_filter': module.params["assign_filter"],
+        'imports': module.params["imports"],
+        'groups': module.params["groups"],
+        'vars': module.params["vars"],
+        'notes': module.params["notes"],
+        'notes_url': module.params["notes_url"],
     }
 
     try:
@@ -261,8 +250,8 @@ def main():
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % e)
 
-    changed, diff = icinga_object.update(state)
-    module.exit_json(changed=changed, object_name=object_name, data=icinga_object.data, diff=diff)
+    changed, diff = icinga_object.update(module.params["state"])
+    module.exit_json(changed=changed, object_name=module.params["object_name"], data=icinga_object.data, diff=diff)
 
 
 # import module snippets

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -35,7 +35,7 @@ author: "Sebastian Gumprich"
 options:
   url:
     description:
-      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+      - HTTP or HTTPS URL in the form (http|https://[user[:pass]]@host.domain[:port]/path
     required: true
     type: str
   use_proxy:

--- a/plugins/modules/icinga_service_template.py
+++ b/plugins/modules/icinga_service_template.py
@@ -35,7 +35,7 @@ author: "Sebastian Gumprich"
 options:
   url:
     description:
-      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@services/templates.domain[:port]/path
+      - HTTP or HTTPS URL in the form (http|https://[user[:pass]]@host.domain[:port]/path
     required: true
     type: str
   use_proxy:

--- a/plugins/modules/icinga_service_template.py
+++ b/plugins/modules/icinga_service_template.py
@@ -251,48 +251,27 @@ def main():
         supports_check_mode=True
     )
 
-    state = module.params["state"]
-    object_name = module.params["object_name"]
-    disabled = module.params["disabled"]
-    check_command = module.params["check_command"]
-    check_interval = module.params["check_interval"]
-    check_period = module.params["check_period"]
-    check_timeout = module.params["check_timeout"]
-    enable_active_checks = module.params["enable_active_checks"]
-    enable_event_handler = module.params["enable_event_handler"]
-    enable_notifications = module.params["enable_notifications"]
-    enable_passive_checks = module.params["enable_passive_checks"]
-    enable_perfdata = module.params["enable_perfdata"]
-    groups = module.params["groups"]
-    imports = module.params["imports"]
-    max_check_attempts = module.params["max_check_attempts"]
-    notes = module.params["notes"]
-    retry_interval = module.params["retry_interval"]
-    use_agent = module.params["use_agent"]
-    vars = module.params["vars"]
-    volatile = module.params["volatile"]
-
     data = {
-        "object_name": object_name,
-        "disabled": disabled,
+        "object_name": module.params["object_name"],
+        "disabled": module.params["disabled"],
         "object_type": "template",
-        "check_command": check_command,
-        "check_interval": check_interval,
-        "check_period": check_period,
-        "check_timeout": check_timeout,
-        "enable_active_checks": enable_active_checks,
-        "enable_event_handler": enable_event_handler,
-        "enable_notifications": enable_notifications,
-        "enable_passive_checks": enable_passive_checks,
-        "enable_perfdata": enable_perfdata,
-        "groups": groups,
-        "imports": imports,
-        "max_check_attempts": max_check_attempts,
-        "notes": notes,
-        "retry_interval": retry_interval,
-        "use_agent": use_agent,
-        "vars": vars,
-        "volatile": volatile,
+        "check_command": module.params["check_command"],
+        "check_interval": module.params["check_interval"],
+        "check_period": module.params["check_period"],
+        "check_timeout": module.params["check_timeout"],
+        "enable_active_checks": module.params["enable_active_checks"],
+        "enable_event_handler": module.params["enable_event_handler"],
+        "enable_notifications": module.params["enable_notifications"],
+        "enable_passive_checks": module.params["enable_passive_checks"],
+        "enable_perfdata": module.params["enable_perfdata"],
+        "groups": module.params["groups"],
+        "imports": module.params["imports"],
+        "max_check_attempts": module.params["max_check_attempts"],
+        "notes": module.params["notes"],
+        "retry_interval": module.params["retry_interval"],
+        "use_agent": module.params["use_agent"],
+        "vars": module.params["vars"],
+        "volatile": module.params["volatile"],
     }
 
     try:
@@ -300,8 +279,8 @@ def main():
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % e)
 
-    changed, diff = icinga_object.update(state)
-    module.exit_json(changed=changed, object_name=object_name, data=icinga_object.data, diff=diff)
+    changed, diff = icinga_object.update(module.params["state"])
+    module.exit_json(changed=changed, object_name=module.params["object_name"], data=icinga_object.data, diff=diff)
 
 
 # import module snippets

--- a/plugins/modules/icinga_servicegroup.py
+++ b/plugins/modules/icinga_servicegroup.py
@@ -35,7 +35,7 @@ author: "Sebastian Gumprich"
 options:
   url:
     description:
-      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+      - HTTP or HTTPS URL in the form (http|https://[user[:pass]]@host.domain[:port]/path
     required: true
     type: str
   use_proxy:

--- a/plugins/modules/icinga_servicegroup.py
+++ b/plugins/modules/icinga_servicegroup.py
@@ -146,16 +146,11 @@ def main():
         supports_check_mode=True
     )
 
-    state = module.params["state"]
-    object_name = module.params["object_name"]
-    display_name = module.params["display_name"]
-    assign_filter = module.params["assign_filter"]
-
     data = {
-        'object_name': object_name,
+        'object_name': module.params["object_name"],
         'object_type': "object",
-        'display_name': display_name,
-        'assign_filter': assign_filter,
+        'display_name': module.params["display_name"],
+        'assign_filter': module.params["assign_filter"],
     }
 
     try:
@@ -163,8 +158,8 @@ def main():
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % e)
 
-    changed, diff = icinga_object.update(state)
-    module.exit_json(changed=changed, object_name=object_name, data=icinga_object.data, diff=diff)
+    changed, diff = icinga_object.update(module.params["state"])
+    module.exit_json(changed=changed, object_name=module.params["object_name"], data=icinga_object.data, diff=diff)
 
 
 # import module snippets

--- a/plugins/modules/icinga_timeperiod.py
+++ b/plugins/modules/icinga_timeperiod.py
@@ -153,18 +153,12 @@ def main():
         supports_check_mode=True
     )
 
-    state = module.params["state"]
-    object_name = module.params["object_name"]
-    display_name = module.params["display_name"]
-    imports = module.params["imports"]
-    ranges = module.params["ranges"]
-
     data = {
-        'object_name': object_name,
+        'object_name': module.params["object_name"],
         'object_type': "object",
-        'display_name': display_name,
-        'imports': imports,
-        'ranges': ranges,
+        'display_name': module.params["display_name"],
+        'imports': module.params["imports"],
+        'ranges': module.params["ranges"],
     }
 
     try:
@@ -172,8 +166,8 @@ def main():
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % e)
 
-    changed, diff = icinga_object.update(state)
-    module.exit_json(changed=changed, object_name=object_name, data=icinga_object.data, diff=diff)
+    changed, diff = icinga_object.update(module.params["state"])
+    module.exit_json(changed=changed, object_name=module.params["object_name"], data=icinga_object.data, diff=diff)
 
 
 # import module snippets

--- a/plugins/modules/icinga_timeperiod.py
+++ b/plugins/modules/icinga_timeperiod.py
@@ -35,7 +35,7 @@ author: "Sebastian Gumprich"
 options:
   url:
     description:
-      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+      - HTTP or HTTPS URL in the form (http|https://[user[:pass]]@host.domain[:port]/path
     required: true
     type: str
   use_proxy:

--- a/plugins/modules/icinga_user.py
+++ b/plugins/modules/icinga_user.py
@@ -170,24 +170,15 @@ def main():
         supports_check_mode=True
     )
 
-    state = module.params["state"]
-    object_name = module.params["object_name"]
-    display_name = module.params["display_name"]
-    imports = module.params["imports"]
-    disabled = module.params["disabled"]
-    email = module.params["email"]
-    pager = module.params["pager"]
-    period = module.params["period"]
-
     data = {
-        'object_name': object_name,
+        'object_name': module.params["object_name"],
         'object_type': "object",
-        'display_name': display_name,
-        'imports': imports,
-        'disabled': disabled,
-        'email': email,
-        'pager': pager,
-        'period': period,
+        'display_name': module.params["display_name"],
+        'imports': module.params["imports"],
+        'disabled': module.params["disabled"],
+        'email': module.params["email"],
+        'pager': module.params["pager"],
+        'period': module.params["period"],
     }
 
     try:
@@ -195,8 +186,8 @@ def main():
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % e)
 
-    changed, diff = icinga_object.update(state)
-    module.exit_json(changed=changed, object_name=object_name, data=icinga_object.data, diff=diff)
+    changed, diff = icinga_object.update(module.params["state"])
+    module.exit_json(changed=changed, object_name=module.params["object_name"], data=icinga_object.data, diff=diff)
 
 
 # import module snippets

--- a/plugins/modules/icinga_user.py
+++ b/plugins/modules/icinga_user.py
@@ -35,7 +35,7 @@ author: "Sebastian Gumprich"
 options:
   url:
     description:
-      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+      - HTTP or HTTPS URL in the form (http|https://[user[:pass]]@host.domain[:port]/path
     required: true
     type: str
   use_proxy:

--- a/plugins/modules/icinga_user_template.py
+++ b/plugins/modules/icinga_user_template.py
@@ -148,18 +148,12 @@ def main():
         supports_check_mode=True
     )
 
-    state = module.params["state"]
-    object_name = module.params["object_name"]
-    imports = module.params["imports"]
-    period = module.params["period"]
-    enable_notifications = module.params["enable_notifications"]
-
     data = {
-        'object_name': object_name,
+        'object_name': module.params["object_name"],
         'object_type': "template",
-        'imports': imports,
-        'period': period,
-        'enable_notifications': enable_notifications,
+        'imports': module.params["imports"],
+        'period': module.params["period"],
+        'enable_notifications': module.params["enable_notifications"],
     }
 
     try:
@@ -167,8 +161,8 @@ def main():
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % e)
 
-    changed, diff = icinga_object.update(state)
-    module.exit_json(changed=changed, object_name=object_name, data=icinga_object.data, diff=diff)
+    changed, diff = icinga_object.update(module.params["state"])
+    module.exit_json(changed=changed, object_name=module.params["object_name"], data=icinga_object.data, diff=diff)
 
 
 # import module snippets

--- a/plugins/modules/icinga_user_template.py
+++ b/plugins/modules/icinga_user_template.py
@@ -35,7 +35,7 @@ author: "Lars Krahl"
 options:
   url:
     description:
-      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+      - HTTP or HTTPS URL in the form (http|https://[user[:pass]]@host.domain[:port]/path
     required: true
     type: str
   use_proxy:


### PR DESCRIPTION
Intermediate variable assignments only make sense, if the contents are manipulated in the program logic. Removed instances where this was not the case.
Also minor fix in documentation.
