### PR TITLE
github-action to automatically create release-drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           future_release: ${{ steps.version.outputs.next-version }}
 
-      - name: Generate changelog for the release
-        uses: charmixer/auto-changelog-action@8095796
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          since_tag: ${{ steps.previoustag.outputs.tag }}
-          future_release: ${{ steps.version.outputs.next-version }}
-          output: CHANGELOGRELEASE.md
-
       - name: push changelog
         uses: github-actions-x/commit@v2.6
         with:
@@ -48,6 +40,14 @@ jobs:
           files: CHANGELOG.md
           name: T-Systems MMS
           email: frage@t-systems-mms.com
+
+      - name: Generate changelog for the release
+        uses: charmixer/auto-changelog-action@8095796
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          since_tag: ${{ steps.previoustag.outputs.tag }}
+          future_release: ${{ steps.version.outputs.next-version }}
+          output: CHANGELOGRELEASE.md
 
       - name: Read CHANGELOG.md
         id: package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: New release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  generate_changelog:
+    runs-on: ubuntu-latest
+    name: create release draft
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@master"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: calculate next version
+        id: version
+        uses: patrickjahns/version-drafter-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate changelog
+        uses: charmixer/auto-changelog-action@8095796
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          future_release: ${{ steps.version.outputs.next-version }}
+
+      - name: Generate changelog for the release
+        uses: charmixer/auto-changelog-action@8095796
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          since_tag: ${{ steps.previoustag.outputs.tag }}
+          future_release: ${{ steps.version.outputs.next-version }}
+          output: CHANGELOGRELEASE.md
+
+      - name: push changelog
+        uses: github-actions-x/commit@v2.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          push-branch: 'master'
+          commit-message: 'update changelog'
+          force-add: 'true'
+          files: CHANGELOG.md
+          name: T-Systems MMS
+          email: frage@t-systems-mms.com
+
+      - name: Read CHANGELOG.md
+        id: package
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./CHANGELOGRELEASE.md
+
+      - name: Create Release draft
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          release_name: ${{ steps.version.outputs.next-version }}
+          tag_name: ${{ steps.version.outputs.next-version }}
+          body: |
+            ${{ steps.package.outputs.content }}
+          draft: true


### PR DESCRIPTION
This does the following:

* get the previous tag (to generate the changelog from this tag)
* get the next tag with the help of labels on PRs (major, minor, patch)
* generate a changelog and push it
* create a release draft with the generated changelog and the release- and tag-name of the next tag

This release draft can then be published after reviewing it. Next step is then to create a new action that automatically creates a new ansible-galaxy release when a new github-release is published. 

Taken from here: https://github.com/dev-sec/ansible-ssh-hardening/runs/744797890?check_suite_focus=true