### PR TITLE
further improve error messages for different errors

### DIFF
--- a/plugins/module_utils/icinga.py
+++ b/plugins/module_utils/icinga.py
@@ -33,8 +33,10 @@ class Icinga2APIObject:
         if rsp:
             body = json.loads(rsp.read())
         if info['status'] >= 400:
-            body = info['body']
-        return {'code': info['status'], 'data': body, 'msg': info['msg']}
+            body = json.loads(info['body'])['error']
+        if info['status'] < 0:
+            body = info['msg']
+        return {'code': info['status'], 'data': body}
 
     def exists(self, find_by='name'):
         ret = self.call_url(
@@ -111,7 +113,7 @@ class Icinga2APIObject:
                             changed = True
                             diff_result.update({'after': 'state: absent\n'})
                         else:
-                            self.module.fail_json(msg="bad return code while creating: %d. Error message: %s" % (ret['code'], ret['msg']))
+                            self.module.fail_json(msg="bad return code while deleting: %d. Error message: %s" % (ret['code'], ret['data']))
                     except Exception as e:
                         self.module.fail_json(msg="exception when deleting: " + str(e))
 
@@ -128,7 +130,7 @@ class Icinga2APIObject:
                 elif ret['code'] == 304:
                     changed = False
                 else:
-                    self.module.fail_json(msg="bad return code while creating: %d. Error message: %s" % (ret['code'], ret['msg']))
+                    self.module.fail_json(msg="bad return code while modifying: %d. Error message: %s" % (ret['code'], ret['data']))
 
         else:
             diff_result.update({'before': 'state: absent\n'})
@@ -143,7 +145,7 @@ class Icinga2APIObject:
                             changed = True
                             diff_result.update({'after': 'state: created\n'})
                         else:
-                            self.module.fail_json(msg="bad return code while creating: %d. Error message: %s" % (ret['code'], ret['msg']))
+                            self.module.fail_json(msg="bad return code while creating: %d. Error message: %s" % (ret['code'], ret['data']))
                     except Exception as e:
                         self.module.fail_json(msg="exception while creating: " + str(e))
         return changed, diff_result

--- a/plugins/module_utils/icinga.py
+++ b/plugins/module_utils/icinga.py
@@ -29,14 +29,19 @@ class Icinga2APIObject:
         url = self.module.params.get("url") + "/director" + path
         rsp, info = fetch_url(module=self.module, url=url, data=data, headers=headers, method=method,
                               use_proxy=self.module.params['use_proxy'])
-        body = ''
+        content = ''
+        error = ''
         if rsp:
-            body = json.loads(rsp.read())
+            content = json.loads(rsp.read())
         if info['status'] >= 400:
-            body = json.loads(info['body'])['error']
+            try:
+                content = json.loads(info["body"])
+                error = content['error']
+            except ValueError:
+                error = info['msg']
         if info['status'] < 0:
-            body = info['msg']
-        return {'code': info['status'], 'data': body}
+            error = info['msg']
+        return {'code': info['status'], 'data': content, 'error': error}
 
     def exists(self, find_by='name'):
         ret = self.call_url(
@@ -113,7 +118,7 @@ class Icinga2APIObject:
                             changed = True
                             diff_result.update({'after': 'state: absent\n'})
                         else:
-                            self.module.fail_json(msg="bad return code while deleting: %d. Error message: %s" % (ret['code'], ret['data']))
+                            self.module.fail_json(msg="bad return code while deleting: %d. Error message: %s" % (ret['code'], ret['error']))
                     except Exception as e:
                         self.module.fail_json(msg="exception when deleting: " + str(e))
 
@@ -130,7 +135,7 @@ class Icinga2APIObject:
                 elif ret['code'] == 304:
                     changed = False
                 else:
-                    self.module.fail_json(msg="bad return code while modifying: %d. Error message: %s" % (ret['code'], ret['data']))
+                    self.module.fail_json(msg="bad return code while modifying: %d. Error message: %s" % (ret['code'], ret['error']))
 
         else:
             diff_result.update({'before': 'state: absent\n'})
@@ -145,7 +150,7 @@ class Icinga2APIObject:
                             changed = True
                             diff_result.update({'after': 'state: created\n'})
                         else:
-                            self.module.fail_json(msg="bad return code while creating: %d. Error message: %s" % (ret['code'], ret['data']))
+                            self.module.fail_json(msg="bad return code while creating: %d. Error message: %s" % (ret['code'], ret['error']))
                     except Exception as e:
                         self.module.fail_json(msg="exception while creating: " + str(e))
         return changed, diff_result


### PR DESCRIPTION
Before:
For icinga errors:
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "bad return code while creating: 404. Error message: HTTP Error 404: Not Found"}
```

For networking errors (proxy):

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "bad return code while creating: -1."}
```

After:
For icinga errors:

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "bad return code while modifying: 404. Error message: Failed to load icinga_host \"StandardServer\""}
```

For networking errors (proxy):

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "bad return code while creating: -1. Error message: Request failed: <urlopen error Tunnel connection failed: 302 Found>"}
```

For non-json errors (401):

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized"}
```