### PR TITLE
when deleting objects, only the object_name is required 

### DIFF
--- a/hacking/update_examples_and_tests.sh
+++ b/hacking/update_examples_and_tests.sh
@@ -16,6 +16,9 @@ for module in ../plugins/modules/*.py; do
     echo "---" | tee "../tests/integration/targets/icinga/roles/icinga/tasks/absent_${module_name}.yml" 1> /dev/null
     sed -n '/EXAMPLES/,/"""/{/EXAMPLES/b;/"""/b;p}' "${module}" | tee -a "../tests/integration/targets/icinga/roles/icinga/tasks/absent_${module_name}.yml" 1> /dev/null
     sed -i 's/state: present/state: absent/g' "../tests/integration/targets/icinga/roles/icinga/tasks/absent_${module_name}.yml"
+
+    # delete imports and command from the tests, because they aren't necessary to delete an object
+    # regression test for https://github.com/T-Systems-MMS/ansible-collection-icinga-director/issues/44
     sed -i '/imports:/,+1d' "../tests/integration/targets/icinga/roles/icinga/tasks/absent_${module_name}.yml"
     sed -i '/^\s*command:/d' "../tests/integration/targets/icinga/roles/icinga/tasks/absent_${module_name}.yml"
 

--- a/hacking/update_examples_and_tests.sh
+++ b/hacking/update_examples_and_tests.sh
@@ -4,22 +4,24 @@ for module in ../plugins/modules/*.py; do
     module_name="$(basename "${module}" .py)"
 
     # create examples
-    echo "---" | tee "../examples/${module_name}.yml"
+    echo "---" | tee "../examples/${module_name}.yml" 1> /dev/null
     # https://stackoverflow.com/a/22221307
-    sed -n '/EXAMPLES/,/"""/{/EXAMPLES/b;/"""/b;p}' "${module}" | tee -a "../examples/${module_name}.yml"
+    sed -n '/EXAMPLES/,/"""/{/EXAMPLES/b;/"""/b;p}' "${module}" | tee -a "../examples/${module_name}.yml" 1> /dev/null
 
     # create tests
-    echo "---" | tee "../tests/integration/targets/icinga/roles/icinga/tasks/${module_name}.yml"
-    sed -n '/EXAMPLES/,/"""/{/EXAMPLES/b;/"""/b;p}' "${module}" | tee -a "../tests/integration/targets/icinga/roles/icinga/tasks/${module_name}.yml"
+    echo "---" | tee "../tests/integration/targets/icinga/roles/icinga/tasks/${module_name}.yml" 1> /dev/null
+    sed -n '/EXAMPLES/,/"""/{/EXAMPLES/b;/"""/b;p}' "${module}" | tee -a "../tests/integration/targets/icinga/roles/icinga/tasks/${module_name}.yml" 1> /dev/null
 
-    # create create working tests deleting the hosts
-    echo "---" | tee "../tests/integration/targets/icinga/roles/icinga/tasks/absent_${module_name}.yml"
-    sed -n '/EXAMPLES/,/"""/{/EXAMPLES/b;/"""/b;p}' "${module}" | tee -a "../tests/integration/targets/icinga/roles/icinga/tasks/absent_${module_name}.yml"
+    # create working tests deleting the hosts
+    echo "---" | tee "../tests/integration/targets/icinga/roles/icinga/tasks/absent_${module_name}.yml" 1> /dev/null
+    sed -n '/EXAMPLES/,/"""/{/EXAMPLES/b;/"""/b;p}' "${module}" | tee -a "../tests/integration/targets/icinga/roles/icinga/tasks/absent_${module_name}.yml" 1> /dev/null
     sed -i 's/state: present/state: absent/g' "../tests/integration/targets/icinga/roles/icinga/tasks/absent_${module_name}.yml"
+    sed -i '/imports:/,+1d' "../tests/integration/targets/icinga/roles/icinga/tasks/absent_${module_name}.yml"
+    sed -i '/^\s*command:/d' "../tests/integration/targets/icinga/roles/icinga/tasks/absent_${module_name}.yml"
 
     # create failing tests with wrong password
-    echo "---" | tee "../tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_${module_name}.yml"
-    sed -n '/EXAMPLES/,/"""/{/EXAMPLES/b;/"""/b;p}' "${module}" | tee -a "../tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_${module_name}.yml"
+    echo "---" | tee "../tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_${module_name}.yml" 1> /dev/null
+    sed -n '/EXAMPLES/,/"""/{/EXAMPLES/b;/"""/b;p}' "${module}" | tee -a "../tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_${module_name}.yml" 1> /dev/null
     # replace password variable with wrong password
     sed -i 's/{{ icinga_pass }}/iamwrong/g' "../tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_${module_name}.yml"
 
@@ -37,8 +39,8 @@ for module in ../plugins/modules/*.py; do
 
     # create failing tests with wrong host
     # add test
-    echo "---" | tee "../tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_${module_name}.yml"
-    sed -n '/EXAMPLES/,/"""/{/EXAMPLES/b;/"""/b;p}' "${module}" | tee -a "../tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_${module_name}.yml"
+    echo "---" | tee "../tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_${module_name}.yml" 1> /dev/null
+    sed -n '/EXAMPLES/,/"""/{/EXAMPLES/b;/"""/b;p}' "${module}" | tee -a "../tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_${module_name}.yml" 1> /dev/null
     # replace url varuable with nonexisting url
     sed -i 's/{{ icinga_url }}/http:\/\/nonexistant/g' "../tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_${module_name}.yml"
 

--- a/plugins/modules/icinga_command.py
+++ b/plugins/modules/icinga_command.py
@@ -241,8 +241,10 @@ def main():
         arguments=dict(type="dict", default=None),
     )
 
-    # When deleting objects, only the name is necessary
-    required_if = [("state", "present", ["url", "object_name", "command"])]
+    # When deleting objects, only the name is necessary, so we cannot use
+    # required=True in the argument_spec. Instead we define here what is
+    # necessary when state is present
+    required_if = [("state", "present", ["command"])]
 
     # Define the main module
     module = AnsibleModule(

--- a/plugins/modules/icinga_command.py
+++ b/plugins/modules/icinga_command.py
@@ -90,12 +90,11 @@ options:
     type: str
   command:
     description:
-      - The command Icinga should run.
+      - The command Icinga should run. Required when state is C(present).
       - Absolute paths are accepted as provided, relative paths are prefixed with "PluginDir + ", similar Constant prefixes are allowed.
       - Spaces will lead to separation of command path and standalone arguments.
       - Please note that this means that we do not support spaces in plugin names and paths right now.
     type: str
-    required: True
   command_type:
     description:
       - Plugin Check commands are what you need when running checks agains your infrastructure.
@@ -232,7 +231,7 @@ def main():
             type="bool", required=False, default=False, choices=[True, False]
         ),
         vars=dict(type="dict", default={}),
-        command=dict(required=True),
+        command=dict(required=False),
         command_type=dict(
             default="PluginCheck",
             choices=["PluginCheck", "PluginNotification", "PluginEvent"],
@@ -242,9 +241,14 @@ def main():
         arguments=dict(type="dict", default=None),
     )
 
+    # When deleting objects, only the name is necessary
+    required_if = [("state", "present", ["url", "object_name", "command"])]
+
     # Define the main module
     module = AnsibleModule(
-        argument_spec=argument_spec, supports_check_mode=True
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=required_if,
     )
 
     # typ von arguments ist eigentlich dict, also ohne Angabe = {}

--- a/plugins/modules/icinga_host.py
+++ b/plugins/modules/icinga_host.py
@@ -206,8 +206,10 @@ def main():
         check_command=dict(required=False),
     )
 
-    # When deleting objects, only the name is necessary
-    required_if = [("state", "present", ["url", "object_name", "imports"])]
+    # When deleting objects, only the name is necessary, so we cannot use
+    # required=True in the argument_spec. Instead we define here what is
+    # necessary when state is present
+    required_if = [("state", "present", ["imports"])]
 
     # Define the main module
     module = AnsibleModule(

--- a/plugins/modules/icinga_host.py
+++ b/plugins/modules/icinga_host.py
@@ -132,8 +132,7 @@ options:
     choices: [True, False]
   imports:
     description:
-      - Choose a Host Template
-    required: true
+      - Choose a Host Template. Required when state is C(present).
     type: list
     elements: str
   zone:
@@ -198,7 +197,7 @@ def main():
         object_name=dict(required=True),
         display_name=dict(required=False),
         groups=dict(type="list", elements="str", default=[], required=False),
-        imports=dict(type="list", elements="str", required=True),
+        imports=dict(type="list", elements="str", required=False),
         disabled=dict(type="bool", default=False, choices=[True, False]),
         address=dict(required=False),
         address6=dict(required=False),
@@ -207,9 +206,14 @@ def main():
         check_command=dict(required=False),
     )
 
+    # When deleting objects, only the name is necessary
+    required_if = [("state", "present", ["url", "object_name", "imports"])]
+
     # Define the main module
     module = AnsibleModule(
-        argument_spec=argument_spec, supports_check_mode=True
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=required_if,
     )
 
     data = {

--- a/plugins/modules/icinga_notification.py
+++ b/plugins/modules/icinga_notification.py
@@ -126,7 +126,6 @@ options:
     description:
       - Importable templates, add as many as you want. Required when state is C(present).
         Please note that order matters when importing properties from multiple templates - last one wins
-    required: true
     type: "list"
     elements: str
 """

--- a/plugins/modules/icinga_notification.py
+++ b/plugins/modules/icinga_notification.py
@@ -124,7 +124,7 @@ options:
     type: "str"
   imports:
     description:
-      - Importable templates, add as many as you want.
+      - Importable templates, add as many as you want. Required when state is C(present).
         Please note that order matters when importing properties from multiple templates - last one wins
     required: true
     type: "list"
@@ -173,7 +173,7 @@ def main():
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
         object_name=dict(required=True),
-        imports=dict(type="list", elements="str", required=True),
+        imports=dict(type="list", elements="str", required=False),
         apply_to=dict(required=True, choices=["service", "host"]),
         assign_filter=dict(required=False),
         notification_interval=dict(required=False),
@@ -181,9 +181,14 @@ def main():
         users=dict(type="list", elements="str", required=False),
     )
 
+    # When deleting objects, only the name is necessary
+    required_if = [("state", "present", ["url", "object_name", "imports"])]
+
     # Define the main module
     module = AnsibleModule(
-        argument_spec=argument_spec, supports_check_mode=True
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=required_if,
     )
 
     data = {

--- a/plugins/modules/icinga_notification.py
+++ b/plugins/modules/icinga_notification.py
@@ -180,8 +180,10 @@ def main():
         users=dict(type="list", elements="str", required=False),
     )
 
-    # When deleting objects, only the name is necessary
-    required_if = [("state", "present", ["url", "object_name", "imports"])]
+    # When deleting objects, only the name is necessary, so we cannot use
+    # required=True in the argument_spec. Instead we define here what is
+    # necessary when state is present
+    required_if = [("state", "present", ["imports"])]
 
     # Define the main module
     module = AnsibleModule(

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_command.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_command.yml
@@ -40,12 +40,9 @@
         set_if: $centreon_verbose$
       '--warning':
         value: $centreon_warning$
-    command: "/opt/centreon-plugins/centreon_plugins.pl"
     command_type: "PluginCheck"
     disabled: false
     object_name: centreon-plugins
-    imports:
-      - centreon-plugins-template
     timeout: "1m"
     vars:
       centreon_maxrepetitions: 20

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_command_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_command_template.yml
@@ -40,7 +40,6 @@
         set_if: $centreon_verbose$
       '--warning':
         value: $centreon_warning$
-    command: "/opt/centreon-plugins/centreon_plugins.pl"
     command_type: "PluginCheck"
     object_name: centreon-plugins-template
     timeout: "2m"

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_host.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_host.yml
@@ -12,8 +12,6 @@
     display_name: "foohost"
     groups:
       - "foohostgroup"
-    imports:
-      - "foohosttemplate"
     vars:
       dnscheck: "no"
     check_command: dummy

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_host_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_host_template.yml
@@ -11,5 +11,3 @@
     check_command: dummy
     groups:
       - "foohostgroup"
-    imports:
-      - ''

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_notification.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_notification.yml
@@ -7,8 +7,6 @@
     url_password: "{{ icinga_pass }}"
     apply_to: host
     assign_filter: 'host.name="foohost"'
-    imports:
-      - foonotificationtemplate
     notification_interval: '0'
     object_name: E-Mail_host
     types:

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_service_apply.yml
@@ -9,8 +9,6 @@
     assign_filter: 'host.vars.HostOS="Linux"'
     apply_for: "host.vars.enabled_notifications"
     display_name: "dummy process"
-    imports:
-      - fooservicetemplate
     groups:
       - fooservicegroup
     vars:

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_user.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_user.yml
@@ -10,5 +10,3 @@
     pager: 'SIP/emergency'
     period: '24/7'
     email: "foouser@example.com"
-    imports:
-      - foousertemplate


### PR DESCRIPTION
When deleting objects, only the object_name is required, so we use required_if here.
I also changed the "absent"-tests so that "imports" and "command" are removed from the task. This way we can test if the issue is fixed.

fixes #44 