### PR TITLE
Allow delegation of the role to a different host

### DIFF
--- a/roles/ansible_icinga/tasks/icinga_command.yml
+++ b/roles/ansible_icinga/tasks/icinga_command.yml
@@ -21,6 +21,7 @@
     zone: "{{ command.0.zone | default(omit) }}"
     vars: "{{ command.0.vars | default(omit) }}"
     arguments: "{{ command.0.arguments | default(omit) }}"
+  delegate_to: "{{ icinga_delegate_to_host | default(omit) }}"
   loop: "{{ icinga_commands|subelements('command_object') }}"
   loop_control:
     loop_var: command

--- a/roles/ansible_icinga/tasks/icinga_command_template.yml
+++ b/roles/ansible_icinga/tasks/icinga_command_template.yml
@@ -22,6 +22,7 @@
     zone: "{{ command_template.0.zone | default(omit) }}"
     vars: "{{ command_template.0.vars | default(omit) }}"
     arguments: "{{ command_template.0.arguments | default(omit) }}"
+  delegate_to: "{{ icinga_delegate_to_host | default(omit) }}"
   loop: "{{ icinga_command_templates|subelements('command_template_object') }}"
   loop_control:
     loop_var: command_template

--- a/roles/ansible_icinga/tasks/icinga_host.yml
+++ b/roles/ansible_icinga/tasks/icinga_host.yml
@@ -21,6 +21,7 @@
     imports: "{{ host.0.imports | default(icinga_host_imports) }}"
     zone: "{{ host.0.zone | default(omit) }}"
     vars: "{{ host.0.vars | default(omit) }}"
+  delegate_to: "{{ icinga_delegate_to_host | default(omit) }}"
   loop: "{{ icinga_hosts|subelements('host_object') }}"
   loop_control:
     loop_var: host

--- a/roles/ansible_icinga/tasks/icinga_host_template.yml
+++ b/roles/ansible_icinga/tasks/icinga_host_template.yml
@@ -22,6 +22,7 @@
     imports: "{{ host_template.0.imports | default(omit) }}"
     zone: "{{ host_template.0.zone | default(omit) }}"
     vars: "{{ host_template.0.vars | default(omit) }}"
+  delegate_to: "{{ icinga_delegate_to_host | default(omit) }}"
   loop: "{{ icinga_host_templates|subelements('host_template_object') }}"
   loop_control:
     loop_var: host_template

--- a/roles/ansible_icinga/tasks/icinga_hostgroup.yml
+++ b/roles/ansible_icinga/tasks/icinga_hostgroup.yml
@@ -15,6 +15,7 @@
     object_name: "{{ hostgroup.1 }}"
     display_name: "{{ hostgroup.0.display_name | default(omit) }}"
     assign_filter: "{{ hostgroup.0.assign_filter | default('host.name=\"' + hostgroup.1 + '-*\"') }}"
+  delegate_to: "{{ icinga_delegate_to_host | default(omit) }}"
   loop: "{{ icinga_hostgroups|subelements('hostgroup_object') }}"
   loop_control:
     loop_var: hostgroup

--- a/roles/ansible_icinga/tasks/icinga_notification.yml
+++ b/roles/ansible_icinga/tasks/icinga_notification.yml
@@ -19,6 +19,7 @@
     apply_to: "{{ notification.0.apply_to | default(omit) }}"
     assign_filter: "{{ notification.0.assign_filter | default(omit) }}"
     imports: "{{ notification.0.imports | default(omit) }}"
+  delegate_to: "{{ icinga_delegate_to_host | default(omit) }}"
   loop: "{{ icinga_notifications|subelements('notification_object') }}"
   loop_control:
     loop_var: notification

--- a/roles/ansible_icinga/tasks/icinga_service_apply.yml
+++ b/roles/ansible_icinga/tasks/icinga_service_apply.yml
@@ -21,6 +21,7 @@
     vars: "{{ service_apply.0.vars | default(omit) }}"
     notes: "{{ service_apply.0.notes | default(omit) }}"
     notes_url: "{{ service_apply.0.notes_url | default(omit) }}"
+  delegate_to: "{{ icinga_delegate_to_host | default(omit) }}"
   loop: "{{ icinga_service_applies|subelements('service_apply_object') }}"
   loop_control:
     loop_var: service_apply

--- a/roles/ansible_icinga/tasks/icinga_service_template.yml
+++ b/roles/ansible_icinga/tasks/icinga_service_template.yml
@@ -32,6 +32,7 @@
     use_agent: "{{ service_template.0.use_agent | default(omit) }}"
     vars: "{{ service_template.0.vars | default(omit) }}"
     volatile: "{{ service_template.0.volatile | default(omit) }}"
+  delegate_to: "{{ icinga_delegate_to_host | default(omit) }}"
   loop: "{{ icinga_service_templates|subelements('service_template_object') }}"
   loop_control:
     loop_var: service_template

--- a/roles/ansible_icinga/tasks/icinga_servicegroup.yml
+++ b/roles/ansible_icinga/tasks/icinga_servicegroup.yml
@@ -15,6 +15,7 @@
     object_name: "{{ servicegroup.1 }}"
     display_name: "{{ servicegroup.0.display_name | default(omit) }}"
     assign_filter: "{{ servicegroup.0.assign_filter | default(omit) }}"
+  delegate_to: "{{ icinga_delegate_to_host | default(omit) }}"
   loop: "{{ icinga_servicegroups|subelements('servicegroup_object') }}"
   loop_control:
     loop_var: servicegroup

--- a/roles/ansible_icinga/tasks/icinga_timeperiod.yml
+++ b/roles/ansible_icinga/tasks/icinga_timeperiod.yml
@@ -16,6 +16,7 @@
     display_name: "{{ timeperiod.0.display_name | default(omit) }}"
     imports: "{{ timeperiod.0.imports | default(omit) }}"
     ranges: "{{ timeperiod.0.ranges | default(omit) }}"
+  delegate_to: "{{ icinga_delegate_to_host | default(omit) }}"
   loop: "{{ icinga_timeperiods|subelements('timeperiod_object') }}"
   loop_control:
     loop_var: timeperiod

--- a/roles/ansible_icinga/tasks/icinga_user.yml
+++ b/roles/ansible_icinga/tasks/icinga_user.yml
@@ -19,6 +19,7 @@
     period: "{{ user.0.period | default(omit) }}"
     disabled: "{{ user.0.disabled | default(omit) }}"
     email: "{{ user.0.email | default(icinga_user_email) }}"
+  delegate_to: "{{ icinga_delegate_to_host | default(omit) }}"
   loop: "{{ icinga_users|subelements('user_object') }}"
   loop_control:
     loop_var: user

--- a/roles/ansible_icinga/tasks/icinga_user_template.yml
+++ b/roles/ansible_icinga/tasks/icinga_user_template.yml
@@ -16,6 +16,7 @@
     imports: "{{ user_template.0.imports | default(omit) }}"
     period: "{{ user_template.0.period | default(omit) }}"
     enable_notifications: "{{ user_template.0.enable_notifications | default(omit) }}"
+  delegate_to: "{{ icinga_delegate_to_host | default(omit) }}"
   loop: "{{ icinga_user_templates|subelements('user_template_object') }}"
   loop_control:
     loop_var: user_template


### PR DESCRIPTION
Make it possible to change from which host the queries to the director are issued.
This allows for example for splitting your configuration across multiple host_vars or group_vars and the queries still being issued from a single host with access to the directors API (e.g. localhost).