### PR TITLE
Add execution parms

### DIFF
--- a/examples/icinga_service_apply.yml
+++ b/examples/icinga_service_apply.yml
@@ -10,14 +10,14 @@
     check_command: hostalive
     display_name: "dummy process"
     check_interval: "10m"
-    check_period: "24x7"
+    check_period: "24/7"
     check_timeout: "1m"
     enable_active_checks: true
     enable_event_handler: true
     enable_notifications: true
     enable_passive_checks: false
     enable_perfdata: false
-    max_check_attempts: 5
+    max_check_attempts: "5"
     retry_interval: "3m"
     imports:
       - fooservicetemplate

--- a/examples/icinga_service_apply.yml
+++ b/examples/icinga_service_apply.yml
@@ -9,6 +9,16 @@
     assign_filter: 'host.name="foohost"'
     check_command: hostalive
     display_name: "dummy process"
+    check_interval: "10m"
+    check_period: "24x7"
+    check_timeout: "1m"
+    enable_active_checks: true
+    enable_event_handler: true
+    enable_notifications: true
+    enable_passive_checks: false
+    enable_perfdata: false
+    max_check_attempts: 5
+    retry_interval: "3m"
     imports:
       - fooservicetemplate
     groups:

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -103,6 +103,56 @@ options:
       - Check command definition
     required: false
     type: str
+  check_interval:
+    description:
+      - Your regular check interval
+    required: false
+    type: str
+  check_period:
+    description:
+      - The name of a time period which determines when this object should be monitored. Not limited by default.
+    required: false
+    type: str
+  check_timeout:
+    description:
+      - Check command timeout in seconds. Overrides the CheckCommand's timeout attribute
+    required: false
+    type: str
+  enable_active_checks:
+    description:
+      - Whether to actively check this object
+    required: false
+    type: "bool"
+  enable_event_handler:
+    description:
+      - Whether to enable event handlers this object
+    required: false
+    type: "bool"
+  enable_notifications:
+    description:
+      - Whether to send notifications for this object
+    required: false
+    type: "bool"
+  enable_passive_checks:
+    description:
+      - Whether to accept passive check results for this object
+    required: false
+    type: "bool"
+  enable_perfdata:
+    description:
+      - Whether to process performance data provided by this object
+    required: false
+    type: "bool"
+  max_check_attempts:
+    description:
+      - Defines after how many check attempts a new hard state is reached
+    required: false
+    type: str
+  retry_interval:
+    description:
+      - Retry interval, will be applied after a state change unless the next hard state is reached
+    required: false
+    type: str
   groups:
     description:
       - Service groups that should be directly assigned to this service.
@@ -224,6 +274,16 @@ def main():
         object_name=dict(required=True),
         display_name=dict(required=False),
         check_command=dict(required=False),
+        check_interval=dict(required=False),
+        check_period=dict(required=False),
+        check_timeout=dict(required=False),
+        enable_active_checks=dict(type="bool", required=False),
+        enable_event_handler=dict(type="bool", required=False),
+        enable_notifications=dict(type="bool", required=False),
+        enable_passive_checks=dict(type="bool", required=False),
+        enable_perfdata=dict(type="bool", required=False),
+        max_check_attempts=dict(required=False),
+        retry_interval=dict(required=False),
         apply_for=dict(required=False),
         assign_filter=dict(required=False),
         imports=dict(type="list", elements="str", required=False),
@@ -244,12 +304,23 @@ def main():
         "object_type": "apply",
         "apply_for": module.params["apply_for"],
         "check_command": module.params["check_command"],
+        "check_interval": module.params["check_interval"],
+        "check_period": module.params["check_period"],
+        "check_timeout": module.params["check_timeout"],
+        "enable_active_checks": module.params["enable_active_checks"],
+        "enable_event_handler": module.params["enable_event_handler"],
+        "enable_notifications": module.params["enable_notifications"],
+        "enable_passive_checks": module.params["enable_passive_checks"],
+        "enable_perfdata": module.params["enable_perfdata"],
+        "max_check_attempts": module.params["max_check_attempts"],
+        "retry_interval": module.params["retry_interval"],
         "assign_filter": module.params["assign_filter"],
         "imports": module.params["imports"],
         "groups": module.params["groups"],
         "vars": module.params["vars"],
         "notes": module.params["notes"],
         "notes_url": module.params["notes_url"],
+
     }
 
     icinga_object = ServiceApplyRule(module=module, data=data)

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -212,6 +212,16 @@ EXAMPLES = """
     assign_filter: 'host.name="foohost"'
     check_command: hostalive
     display_name: "dummy process"
+    check_interval: "10m"
+    check_period: "24x7"
+    check_timeout: "1m"
+    enable_active_checks: true
+    enable_event_handler: true
+    enable_notifications: true
+    enable_passive_checks: false
+    enable_perfdata: false
+    max_check_attempts: 5
+    retry_interval: "3m"
     imports:
       - fooservicetemplate
     groups:

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -158,14 +158,14 @@ EXAMPLES = """
     check_command: hostalive
     display_name: "dummy process"
     check_interval: "10m"
-    check_period: "24x7"
+    check_period: "24/7"
     check_timeout: "1m"
     enable_active_checks: true
     enable_event_handler: true
     enable_notifications: true
     enable_passive_checks: false
     enable_perfdata: false
-    max_check_attempts: 5
+    max_check_attempts: "5"
     retry_interval: "3m"
     imports:
       - fooservicetemplate

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -105,7 +105,7 @@ options:
     type: str
   check_interval:
     description:
-      - Your regular check interval
+      - Your regular check interval-
     required: false
     type: str
   check_period:
@@ -115,42 +115,42 @@ options:
     type: str
   check_timeout:
     description:
-      - Check command timeout in seconds. Overrides the CheckCommand's timeout attribute
+      - Check command timeout in seconds. Overrides the CheckCommand's timeout attribute.
     required: false
     type: str
   enable_active_checks:
     description:
-      - Whether to actively check this object
+      - Whether to actively check this object.
     required: false
     type: "bool"
   enable_event_handler:
     description:
-      - Whether to enable event handlers this object
+      - Whether to enable event handlers this object.
     required: false
     type: "bool"
   enable_notifications:
     description:
-      - Whether to send notifications for this object
+      - Whether to send notifications for this object.
     required: false
     type: "bool"
   enable_passive_checks:
     description:
-      - Whether to accept passive check results for this object
+      - Whether to accept passive check results for this object.
     required: false
     type: "bool"
   enable_perfdata:
     description:
-      - Whether to process performance data provided by this object
+      - Whether to process performance data provided by this object.
     required: false
     type: "bool"
   max_check_attempts:
     description:
-      - Defines after how many check attempts a new hard state is reached
+      - Defines after how many check attempts a new hard state is reached.
     required: false
     type: str
   retry_interval:
     description:
-      - Retry interval, will be applied after a state change unless the next hard state is reached
+      - Retry interval, will be applied after a state change unless the next hard state is reached.
     required: false
     type: str
   groups:

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -320,7 +320,6 @@ def main():
         "vars": module.params["vars"],
         "notes": module.params["notes"],
         "notes_url": module.params["notes_url"],
-
     }
 
     icinga_object = ServiceApplyRule(module=module, data=data)

--- a/roles/ansible_icinga/tasks/icinga_service_apply.yml
+++ b/roles/ansible_icinga/tasks/icinga_service_apply.yml
@@ -21,6 +21,16 @@
     vars: "{{ service_apply.0.vars | default(omit) }}"
     notes: "{{ service_apply.0.notes | default(omit) }}"
     notes_url: "{{ service_apply.0.notes_url | default(omit) }}"
+    check_interval: "{{ service_apply.0.check_interval | default(omit) }}"
+    check_period: "{{ service_apply.0.check_period | default(omit) }}"
+    check_timeout: "{{ service_apply.0.check_timeout | default(omit) }}"
+    enable_active_checks: "{{ service_apply.0.enable_active_checks | default(omit) }}"
+    enable_event_handler: "{{ service_apply.0.enable_event_handler | default(omit) }}"
+    enable_notifications: "{{ service_apply.0.enable_notifications | default(omit) }}"
+    enable_passive_checks: "{{ service_apply.0.enable_passive_checks | default(omit) }}"
+    enable_perfdata: "{{ service_apply.0.enable_perfdata | default(omit) }}"
+    max_check_attempts: "{{ service_apply.0.max_check_attempts | default(omit) }}"
+    retry_interval: "{{ service_apply.0.retry_interval | default(omit) }}"
   loop: "{{ icinga_service_applies|subelements('service_apply_object') }}"
   loop_control:
     loop_var: service_apply

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_service_apply.yml
@@ -9,6 +9,16 @@
     assign_filter: 'host.name="foohost"'
     check_command: hostalive
     display_name: "dummy process"
+    check_interval: "10m"
+    check_period: "24x7"
+    check_timeout: "1m"
+    enable_active_checks: true
+    enable_event_handler: true
+    enable_notifications: true
+    enable_passive_checks: false
+    enable_perfdata: false
+    max_check_attempts: 5
+    retry_interval: "3m"
     groups:
       - fooservicegroup
     vars:

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_service_apply.yml
@@ -10,14 +10,14 @@
     check_command: hostalive
     display_name: "dummy process"
     check_interval: "10m"
-    check_period: "24x7"
+    check_period: "24/7"
     check_timeout: "1m"
     enable_active_checks: true
     enable_event_handler: true
     enable_notifications: true
     enable_passive_checks: false
     enable_perfdata: false
-    max_check_attempts: 5
+    max_check_attempts: "5"
     retry_interval: "3m"
     groups:
       - fooservicegroup

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service_apply.yml
@@ -10,14 +10,14 @@
     check_command: hostalive
     display_name: "dummy process"
     check_interval: "10m"
-    check_period: "24x7"
+    check_period: "24/7"
     check_timeout: "1m"
     enable_active_checks: true
     enable_event_handler: true
     enable_notifications: true
     enable_passive_checks: false
     enable_perfdata: false
-    max_check_attempts: 5
+    max_check_attempts: "5"
     retry_interval: "3m"
     imports:
       - fooservicetemplate

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service_apply.yml
@@ -9,6 +9,16 @@
     assign_filter: 'host.name="foohost"'
     check_command: hostalive
     display_name: "dummy process"
+    check_interval: "10m"
+    check_period: "24x7"
+    check_timeout: "1m"
+    enable_active_checks: true
+    enable_event_handler: true
+    enable_notifications: true
+    enable_passive_checks: false
+    enable_perfdata: false
+    max_check_attempts: 5
+    retry_interval: "3m"
     imports:
       - fooservicetemplate
     groups:

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_service_apply.yml
@@ -10,14 +10,14 @@
     check_command: hostalive
     display_name: "dummy process"
     check_interval: "10m"
-    check_period: "24x7"
+    check_period: "24/7"
     check_timeout: "1m"
     enable_active_checks: true
     enable_event_handler: true
     enable_notifications: true
     enable_passive_checks: false
     enable_perfdata: false
-    max_check_attempts: 5
+    max_check_attempts: "5"
     retry_interval: "3m"
     imports:
       - fooservicetemplate

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_service_apply.yml
@@ -9,6 +9,16 @@
     assign_filter: 'host.name="foohost"'
     check_command: hostalive
     display_name: "dummy process"
+    check_interval: "10m"
+    check_period: "24x7"
+    check_timeout: "1m"
+    enable_active_checks: true
+    enable_event_handler: true
+    enable_notifications: true
+    enable_passive_checks: false
+    enable_perfdata: false
+    max_check_attempts: 5
+    retry_interval: "3m"
     imports:
       - fooservicetemplate
     groups:

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_apply.yml
@@ -10,14 +10,14 @@
     check_command: hostalive
     display_name: "dummy process"
     check_interval: "10m"
-    check_period: "24x7"
+    check_period: "24/7"
     check_timeout: "1m"
     enable_active_checks: true
     enable_event_handler: true
     enable_notifications: true
     enable_passive_checks: false
     enable_perfdata: false
-    max_check_attempts: 5
+    max_check_attempts: "5"
     retry_interval: "3m"
     imports:
       - fooservicetemplate

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_apply.yml
@@ -9,6 +9,16 @@
     assign_filter: 'host.name="foohost"'
     check_command: hostalive
     display_name: "dummy process"
+    check_interval: "10m"
+    check_period: "24x7"
+    check_timeout: "1m"
+    enable_active_checks: true
+    enable_event_handler: true
+    enable_notifications: true
+    enable_passive_checks: false
+    enable_perfdata: false
+    max_check_attempts: 5
+    retry_interval: "3m"
     imports:
       - fooservicetemplate
     groups:


### PR DESCRIPTION
Issue #65 
It's now possible to add execution parameters like:
check_interval: 
check_period: 
check_timeout: 
enable_active_checks: 
enable_event_handler: 
enable_notifications: 
enable_passive_checks: 
enable_perfdata: 
max_check_attempts: 
retry_interval:

on service apply level.

Attention: These parameters for service apply can't be edited via directory GUI!