### PR TITLE
fixed "command is missing" while trying to create a command

### DIFF
--- a/plugins/modules/icinga_command.py
+++ b/plugins/modules/icinga_command.py
@@ -253,7 +253,7 @@ def main():
     # When deleting objects, only the name is necessary, so we cannot use
     # required=True in the argument_spec. Instead we define here what is
     # necessary when state is present
-    required_if = [("state", "present", ["command"])]
+    required_if = [("state", "present", ["object_name"])]
 
     # Define the main module
     module = AnsibleModule(


### PR DESCRIPTION
I tried to create a new command for Icinga with a command_template_object in which the command was already specified and a command_object that should inherit properties from the template object. But I always got this error: `"state is present but all of the following are missing: command"`, It turned out that the "required_if" (changed in this pr) led to this error.