### PR TITLE
add name alias for object_name

### DIFF
--- a/plugins/modules/icinga_command.py
+++ b/plugins/modules/icinga_command.py
@@ -66,7 +66,8 @@ options:
     choices: [True, False]
   object_name:
     description:
-      - Name of the service apply rule
+      - Name of the command
+    aliases: ['name']
     required: true
     type: str
   imports:
@@ -188,7 +189,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         imports=dict(type="list", elements="str", required=False, default=[]),
         disabled=dict(
             type="bool", required=False, default=False, choices=[True, False]

--- a/plugins/modules/icinga_command_template.py
+++ b/plugins/modules/icinga_command_template.py
@@ -67,7 +67,8 @@ options:
     choices: [True, False]
   object_name:
     description:
-      - Name of the service apply rule
+      - Name of the command template
+    aliases: ['name']
     required: true
     type: str
   imports:
@@ -187,7 +188,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         imports=dict(type="list", elements="str", required=False, default=[]),
         disabled=dict(
             type="bool", required=False, default=False, choices=[True, False]

--- a/plugins/modules/icinga_endpoint.py
+++ b/plugins/modules/icinga_endpoint.py
@@ -49,6 +49,7 @@ options:
         To make things easier for your users we strongly suggest to use meaningful names for templates.
         E.g. "generic-endpoint" is ugly, "Standard Linux Server" is easier to understand
     required: true
+    aliases: ['name']
     type: str
   host:
     description:
@@ -106,7 +107,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         host=dict(required=False),
         port=dict(required=False, type="int"),
         log_duration=dict(required=False),

--- a/plugins/modules/icinga_host.py
+++ b/plugins/modules/icinga_host.py
@@ -48,6 +48,7 @@ options:
         This is usually a fully qualified host name but it could basically be any kind of string.
         To make things easier for your users we strongly suggest to use meaningful names for templates.
         E.g. "generic-host" is ugly, "Standard Linux Server" is easier to understand
+    aliases: ['name']
     required: true
     type: str
   display_name:
@@ -183,7 +184,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         display_name=dict(required=False),
         groups=dict(type="list", elements="str", default=[], required=False),
         imports=dict(type="list", elements="str", required=False),

--- a/plugins/modules/icinga_host_template.py
+++ b/plugins/modules/icinga_host_template.py
@@ -44,10 +44,11 @@ options:
     type: str
   object_name:
     description:
-      - Icinga object name for this host.
+      - Icinga object name for this host template.
         This is usually a fully qualified host name but it could basically be any kind of string.
         To make things easier for your users we strongly suggest to use meaningful names for templates.
         E.g. "generic-host" is ugly, "Standard Linux Server" is easier to understand
+    aliases: ['name']
     required: true
     type: str
   display_name:
@@ -180,7 +181,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         display_name=dict(required=False),
         groups=dict(type="list", elements="str", default=[], required=False),
         check_command=dict(required=False),

--- a/plugins/modules/icinga_hostgroup.py
+++ b/plugins/modules/icinga_hostgroup.py
@@ -45,6 +45,7 @@ options:
   object_name:
     description:
       - Icinga object name for this hostgroup.
+    aliases: ['name']
     required: true
     type: str
   display_name:
@@ -95,7 +96,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         display_name=dict(required=False),
         assign_filter=dict(required=False),
     )

--- a/plugins/modules/icinga_notification.py
+++ b/plugins/modules/icinga_notification.py
@@ -45,6 +45,7 @@ options:
   object_name:
     description:
       - Name of the notification
+    aliases: ['name']
     required: true
     type: str
   notification_interval:
@@ -149,7 +150,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         imports=dict(type="list", elements="str", required=False),
         apply_to=dict(required=True, choices=["service", "host"]),
         assign_filter=dict(required=False),

--- a/plugins/modules/icinga_notification_template.py
+++ b/plugins/modules/icinga_notification_template.py
@@ -45,6 +45,7 @@ options:
   object_name:
     description:
       - Name of the notification template
+    aliases: ['name']
     required: true
     type: str
   notification_interval:
@@ -124,7 +125,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         notification_interval=dict(required=False),
         states=dict(type="list", elements="str", required=False),
         times_begin=dict(type="int", required=False),

--- a/plugins/modules/icinga_service.py
+++ b/plugins/modules/icinga_service.py
@@ -45,6 +45,7 @@ options:
   object_name:
     description:
       - Name of the service
+    aliases: ['name']
     required: true
     type: str
   check_command:
@@ -284,7 +285,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         disabled=dict(type="bool", default=False, choices=[True, False]),
         check_command=dict(required=False),
         check_interval=dict(required=False),

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -44,7 +44,8 @@ options:
     type: str
   object_name:
     description:
-      - Name for the Icinga service you are going to create
+      - Name for the Icinga service apply rule
+    aliases: ['name']
     required: true
     type: str
   display_name:
@@ -175,7 +176,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         display_name=dict(required=False),
         check_command=dict(required=False),
         apply_for=dict(required=False),

--- a/plugins/modules/icinga_service_template.py
+++ b/plugins/modules/icinga_service_template.py
@@ -45,6 +45,7 @@ options:
   object_name:
     description:
       - Name of the service template
+    aliases: ['name']
     required: true
     type: str
   check_command:
@@ -194,7 +195,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         disabled=dict(type="bool", default=False, choices=[True, False]),
         check_command=dict(required=False),
         check_interval=dict(required=False),

--- a/plugins/modules/icinga_servicegroup.py
+++ b/plugins/modules/icinga_servicegroup.py
@@ -44,7 +44,8 @@ options:
     type: str
   object_name:
     description:
-      - Icinga object name for this servicegroup.
+      - Name for the Icinga servicegroup
+    aliases: ['name']
     required: true
     type: str
   display_name:
@@ -95,7 +96,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         display_name=dict(required=False),
         assign_filter=dict(required=False),
     )

--- a/plugins/modules/icinga_timeperiod.py
+++ b/plugins/modules/icinga_timeperiod.py
@@ -44,7 +44,8 @@ options:
     type: str
   object_name:
     description:
-      - Name of the service apply rule
+      - Name of the time period
+    aliases: ['name']
     required: true
     type: str
   display_name:
@@ -103,7 +104,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         display_name=dict(required=False),
         imports=dict(type="list", elements="str", default=[], required=False),
         ranges=dict(type="dict", required=False),

--- a/plugins/modules/icinga_user.py
+++ b/plugins/modules/icinga_user.py
@@ -44,7 +44,8 @@ options:
     type: str
   object_name:
     description:
-      - Name of the service apply rule
+      - Name of the user
+    aliases: ['name']
     required: true
     type: str
   display_name:
@@ -116,7 +117,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         display_name=dict(required=False),
         disabled=dict(type="bool", default=False, choices=[True, False]),
         imports=dict(type="list", elements="str", required=False),

--- a/plugins/modules/icinga_user_template.py
+++ b/plugins/modules/icinga_user_template.py
@@ -45,6 +45,7 @@ options:
   object_name:
     description:
       - Name of the user template
+    aliases: ['name']
     required: true
     type: str
   imports:
@@ -96,7 +97,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         imports=dict(type="list", elements="str", default=[], required=False),
         period=dict(required=False),
         enable_notifications=dict(type="bool", required=False),

--- a/plugins/modules/icinga_zone.py
+++ b/plugins/modules/icinga_zone.py
@@ -48,6 +48,7 @@ options:
         This is usually a fully qualified host name but it could basically be any kind of string.
         To make things easier for your users we strongly suggest to use meaningful names for templates.
         E.g. "generic-zone" is ugly, "Standard Linux Server" is easier to understand
+    aliases: ['name']
     required: true
     type: str
   is_global:
@@ -94,7 +95,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         url=dict(required=True),
-        object_name=dict(required=True),
+        object_name=dict(required=True, aliases=["name"]),
         is_global=dict(required=False, type="bool", default=False),
         parent=dict(required=False),
     )


### PR DESCRIPTION
If your module is addressing an object, the option for that object should be called name whenever possible, or accept name as an alias.

https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_best_practices.html