### PR TITLE
remove unneeded return values

### DIFF
--- a/plugins/modules/icinga_command.py
+++ b/plugins/modules/icinga_command.py
@@ -171,6 +171,8 @@ EXAMPLES = """
     object_name: centreon-plugins_2
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -239,8 +241,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_command_template.py
+++ b/plugins/modules/icinga_command_template.py
@@ -170,6 +170,8 @@ EXAMPLES = """
     object_name: centreon-plugins-template-2
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -231,8 +233,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_endpoint.py
+++ b/plugins/modules/icinga_endpoint.py
@@ -89,6 +89,8 @@ EXAMPLES = """
     zone: "foozone"
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -131,8 +133,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_host.py
+++ b/plugins/modules/icinga_host.py
@@ -172,6 +172,8 @@ EXAMPLES = """
     accept_config: true
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (

--- a/plugins/modules/icinga_host_template.py
+++ b/plugins/modules/icinga_host_template.py
@@ -167,6 +167,8 @@ EXAMPLES = """
     accept_config: true
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -229,8 +231,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_hostgroup.py
+++ b/plugins/modules/icinga_hostgroup.py
@@ -76,6 +76,8 @@ EXAMPLES = """
     assign_filter: 'host.name="foohost"'
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -118,8 +120,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_notification.py
+++ b/plugins/modules/icinga_notification.py
@@ -133,6 +133,8 @@ EXAMPLES = """
       foo: bar
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -197,8 +199,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_notification_template.py
+++ b/plugins/modules/icinga_notification_template.py
@@ -106,6 +106,8 @@ EXAMPLES = """
     times_end: 120
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -156,8 +158,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_service.py
+++ b/plugins/modules/icinga_service.py
@@ -186,6 +186,8 @@ EXAMPLES = """
     notes_url: "'http://url1' 'http://url2'"
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible.module_utils.common.text.converters import to_text
@@ -344,8 +346,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -131,6 +131,8 @@ EXAMPLES = """
       http_expect: "Yes"
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -210,8 +212,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_service_template.py
+++ b/plugins/modules/icinga_service_template.py
@@ -178,6 +178,8 @@ EXAMPLES = """
     notes_url: "'http://url1' 'http://url2'"
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -250,8 +252,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_servicegroup.py
+++ b/plugins/modules/icinga_servicegroup.py
@@ -76,6 +76,8 @@ EXAMPLES = """
     assign_filter: 'host.name="foo"'
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -118,8 +120,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_timeperiod.py
+++ b/plugins/modules/icinga_timeperiod.py
@@ -87,6 +87,8 @@ EXAMPLES = """
       sunday: "00:00-23:59"
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -129,8 +131,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_user.py
+++ b/plugins/modules/icinga_user.py
@@ -101,6 +101,8 @@ EXAMPLES = """
       - foousertemplate
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -147,8 +149,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_user_template.py
+++ b/plugins/modules/icinga_user_template.py
@@ -80,6 +80,8 @@ EXAMPLES = """
     period: '24/7'
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -120,8 +122,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 

--- a/plugins/modules/icinga_zone.py
+++ b/plugins/modules/icinga_zone.py
@@ -77,6 +77,8 @@ EXAMPLES = """
     parent: "master"
 """
 
+RETURN = r""" # """
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import url_argument_spec
 from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
@@ -117,8 +119,6 @@ def main():
     changed, diff = icinga_object.update(module.params["state"])
     module.exit_json(
         changed=changed,
-        object_name=module.params["object_name"],
-        data=icinga_object.data,
         diff=diff,
     )
 


### PR DESCRIPTION
The initial implementation returned some data from our modules.
This data was only a representation of our inputs, so they were
redundant.