### PR TITLE
Add support to change the check_source / command_endpoint parameter

### DIFF
--- a/examples/icinga_service_apply.yml
+++ b/examples/icinga_service_apply.yml
@@ -29,3 +29,28 @@
       http_uri: "/ready"
       http_string: "Ready"
       http_expect: "Yes"
+- name: Add service apply rule with command_endpoint
+  t_systems_mms.icinga_director.icinga_service_apply:
+    state: present
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "SERVICE_dummy"
+    assign_filter: 'host.name="foohost"'
+    check_command: hostalive
+    display_name: "dummy process"
+    check_interval: "10m"
+    check_period: "24/7"
+    check_timeout: "1m"
+    enable_active_checks: true
+    enable_event_handler: true
+    enable_notifications: true
+    enable_passive_checks: false
+    enable_perfdata: false
+    max_check_attempts: "5"
+    retry_interval: "3m"
+    command_endpoint: "fooendpoint"
+    imports:
+      - fooservicetemplate
+    groups:
+      - fooservicegroup

--- a/plugins/modules/icinga_service_apply.py
+++ b/plugins/modules/icinga_service_apply.py
@@ -124,6 +124,10 @@ options:
     description:
       - The filter where the service apply rule will take effect.
     type: str
+  commnand_endpoint:
+    description:
+      - The host where the service should be executed on.
+    type: str
   imports:
     description:
       - Importable templates, add as many as you want.
@@ -177,6 +181,32 @@ EXAMPLES = """
       http_uri: "/ready"
       http_string: "Ready"
       http_expect: "Yes"
+
+- name: Add service apply rule with command_endpoint
+  t_systems_mms.icinga_director.icinga_service_apply:
+    state: present
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "SERVICE_dummy"
+    assign_filter: 'host.name="foohost"'
+    check_command: hostalive
+    display_name: "dummy process"
+    check_interval: "10m"
+    check_period: "24/7"
+    check_timeout: "1m"
+    enable_active_checks: true
+    enable_event_handler: true
+    enable_notifications: true
+    enable_passive_checks: false
+    enable_perfdata: false
+    max_check_attempts: "5"
+    retry_interval: "3m"
+    command_endpoint: "fooendpoint"
+    imports:
+      - fooservicetemplate
+    groups:
+      - fooservicegroup
 """
 
 RETURN = r""" # """
@@ -240,6 +270,7 @@ def main():
         retry_interval=dict(required=False),
         apply_for=dict(required=False),
         assign_filter=dict(required=False),
+        command_endpoint=dict(required=False),
         imports=dict(type="list", elements="str", required=False),
         groups=dict(type="list", elements="str", default=[], required=False),
         vars=dict(type="dict", default={}),
@@ -268,6 +299,7 @@ def main():
         "enable_perfdata": module.params["enable_perfdata"],
         "max_check_attempts": module.params["max_check_attempts"],
         "retry_interval": module.params["retry_interval"],
+        "command_endpoint": module.params["command_endpoint"],
         "assign_filter": module.params["assign_filter"],
         "imports": module.params["imports"],
         "groups": module.params["groups"],

--- a/roles/ansible_icinga/tasks/icinga_service_apply.yml
+++ b/roles/ansible_icinga/tasks/icinga_service_apply.yml
@@ -18,6 +18,7 @@
     apply_for: "{{ service_apply.0.apply_for | default(omit) }}"
     assign_filter: "{{ service_apply.0.assign_filter | default(omit) }}"
     imports: "{{ service_apply.0.imports | default(omit) }}"
+    imports: "{{ service_apply.0.command_endpoint | default(omit) }}"
     vars: "{{ service_apply.0.vars | default(omit) }}"
     notes: "{{ service_apply.0.notes | default(omit) }}"
     notes_url: "{{ service_apply.0.notes_url | default(omit) }}"

--- a/roles/ansible_icinga/tasks/icinga_service_apply.yml
+++ b/roles/ansible_icinga/tasks/icinga_service_apply.yml
@@ -18,7 +18,7 @@
     apply_for: "{{ service_apply.0.apply_for | default(omit) }}"
     assign_filter: "{{ service_apply.0.assign_filter | default(omit) }}"
     imports: "{{ service_apply.0.imports | default(omit) }}"
-    imports: "{{ service_apply.0.command_endpoint | default(omit) }}"
+    command_endpoint: "{{ service_apply.0.command_endpoint | default(omit) }}"
     vars: "{{ service_apply.0.vars | default(omit) }}"
     notes: "{{ service_apply.0.notes | default(omit) }}"
     notes_url: "{{ service_apply.0.notes_url | default(omit) }}"

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_service_apply.yml
@@ -27,3 +27,26 @@
       http_uri: "/ready"
       http_string: "Ready"
       http_expect: "Yes"
+- name: Add service apply rule with command_endpoint
+  t_systems_mms.icinga_director.icinga_service_apply:
+    state: absent
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "SERVICE_dummy"
+    assign_filter: 'host.name="foohost"'
+    check_command: hostalive
+    display_name: "dummy process"
+    check_interval: "10m"
+    check_period: "24/7"
+    check_timeout: "1m"
+    enable_active_checks: true
+    enable_event_handler: true
+    enable_notifications: true
+    enable_passive_checks: false
+    enable_perfdata: false
+    max_check_attempts: "5"
+    retry_interval: "3m"
+    command_endpoint: "fooendpoint"
+    groups:
+      - fooservicegroup

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_command_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_command_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_command_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_command_template_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_endpoint_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_endpoint_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_host_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_host_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_host_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_host_template_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_hostgroup_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_hostgroup_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_notification_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_notification_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_notification_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_notification_template_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service_apply.yml
@@ -29,3 +29,28 @@
       http_uri: "/ready"
       http_string: "Ready"
       http_expect: "Yes"
+- name: Add service apply rule with command_endpoint
+  t_systems_mms.icinga_director.icinga_service_apply:
+    state: present
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "SERVICE_dummy"
+    assign_filter: 'host.name="foohost"'
+    check_command: hostalive
+    display_name: "dummy process"
+    check_interval: "10m"
+    check_period: "24/7"
+    check_timeout: "1m"
+    enable_active_checks: true
+    enable_event_handler: true
+    enable_notifications: true
+    enable_passive_checks: false
+    enable_perfdata: false
+    max_check_attempts: "5"
+    retry_interval: "3m"
+    command_endpoint: "fooendpoint"
+    imports:
+      - fooservicetemplate
+    groups:
+      - fooservicegroup

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service_apply_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service_apply_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service_template_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_servicegroup_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_servicegroup_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_timeperiod_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_timeperiod_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_user_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_user_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_user_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_user_template_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_zone_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_zone_info.yml
@@ -8,4 +8,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_command_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_command_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_command_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_command_template_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_endpoint_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_endpoint_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_host_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_host_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_host_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_host_template_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_hostgroup_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_hostgroup_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_notification_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_notification_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_notification_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_notification_template_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_service_apply_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_service_apply_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_service_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_service_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_service_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_service_template_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_servicegroup_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_servicegroup_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_timeperiod_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_timeperiod_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_user_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_user_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_user_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_user_template_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_zone_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/no_query_icinga_zone_info.yml
@@ -7,4 +7,5 @@
   register: result
 - assert:
     that:
+      # yamllint disable-line rule:line-length
       - '(result.objects | length) == 1 or (result.objects | length) == 2 or (result.objects | length) == 3'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_command.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_command.yml
@@ -62,6 +62,7 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
 - name: Create command
   t_systems_mms.icinga_director.icinga_command:
@@ -76,6 +77,7 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
 - name: Create event command
   t_systems_mms.icinga_director.icinga_command:
@@ -98,4 +100,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_command_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_command_template.yml
@@ -60,6 +60,7 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
 - name: Create command template
   t_systems_mms.icinga_director.icinga_command_template:
@@ -74,4 +75,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_endpoint.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_endpoint.yml
@@ -13,4 +13,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_host.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_host.yml
@@ -27,4 +27,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_host_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_host_template.yml
@@ -24,4 +24,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_hostgroup.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_hostgroup.yml
@@ -13,4 +13,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_notification.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_notification.yml
@@ -27,4 +27,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_notification_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_notification_template.yml
@@ -20,4 +20,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_service.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_service.yml
@@ -21,4 +21,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_service_apply.yml
@@ -34,4 +34,37 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
+      - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
+- name: Add service apply rule with command_endpoint
+  t_systems_mms.icinga_director.icinga_service_apply:
+    state: present
+    url: http://nonexistant
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "SERVICE_dummy"
+    assign_filter: 'host.name="foohost"'
+    check_command: hostalive
+    display_name: "dummy process"
+    check_interval: "10m"
+    check_period: "24/7"
+    check_timeout: "1m"
+    enable_active_checks: true
+    enable_event_handler: true
+    enable_notifications: true
+    enable_passive_checks: false
+    enable_perfdata: false
+    max_check_attempts: "5"
+    retry_interval: "3m"
+    command_endpoint: "fooendpoint"
+    imports:
+      - fooservicetemplate
+    groups:
+      - fooservicegroup
+  ignore_errors: true
+  register: result
+- assert:
+    that:
+      - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_service_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_service_template.yml
@@ -18,6 +18,7 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
 - name: Create servicetemplate with event command
   t_systems_mms.icinga_director.icinga_service_template:
@@ -35,4 +36,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_servicegroup.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_servicegroup.yml
@@ -13,4 +13,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_timeperiod.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_timeperiod.yml
@@ -19,4 +19,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_user.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_user.yml
@@ -17,4 +17,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_user_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_user_template.yml
@@ -13,4 +13,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_zone.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_zone.yml
@@ -12,4 +12,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_command.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_command.yml
@@ -62,6 +62,7 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
 - name: Create command
   t_systems_mms.icinga_director.icinga_command:
@@ -76,6 +77,7 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
 - name: Create event command
   t_systems_mms.icinga_director.icinga_command:
@@ -98,4 +100,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_command_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_command_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_command_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_command_template.yml
@@ -60,6 +60,7 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
 - name: Create command template
   t_systems_mms.icinga_director.icinga_command_template:
@@ -74,4 +75,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_command_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_command_template_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_endpoint.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_endpoint.yml
@@ -13,4 +13,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_endpoint_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_endpoint_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_host.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_host.yml
@@ -27,4 +27,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_host_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_host_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_host_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_host_template.yml
@@ -24,4 +24,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_host_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_host_template_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_hostgroup.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_hostgroup.yml
@@ -13,4 +13,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_hostgroup_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_hostgroup_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_notification.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_notification.yml
@@ -27,4 +27,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_notification_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_notification_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_notification_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_notification_template.yml
@@ -20,4 +20,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_notification_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_notification_template_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service.yml
@@ -21,4 +21,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_apply.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_apply.yml
@@ -34,4 +34,37 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
+      - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
+- name: Add service apply rule with command_endpoint
+  t_systems_mms.icinga_director.icinga_service_apply:
+    state: present
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: iamwrong
+    object_name: "SERVICE_dummy"
+    assign_filter: 'host.name="foohost"'
+    check_command: hostalive
+    display_name: "dummy process"
+    check_interval: "10m"
+    check_period: "24/7"
+    check_timeout: "1m"
+    enable_active_checks: true
+    enable_event_handler: true
+    enable_notifications: true
+    enable_passive_checks: false
+    enable_perfdata: false
+    max_check_attempts: "5"
+    retry_interval: "3m"
+    command_endpoint: "fooendpoint"
+    imports:
+      - fooservicetemplate
+    groups:
+      - fooservicegroup
+  ignore_errors: true
+  register: result
+- assert:
+    that:
+      - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_apply_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_apply_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_template.yml
@@ -18,6 +18,7 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
 - name: Create servicetemplate with event command
   t_systems_mms.icinga_director.icinga_service_template:
@@ -35,4 +36,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_service_template_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_servicegroup.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_servicegroup.yml
@@ -13,4 +13,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_servicegroup_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_servicegroup_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_timeperiod.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_timeperiod.yml
@@ -19,4 +19,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_timeperiod_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_timeperiod_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_user.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_user.yml
@@ -17,4 +17,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_user_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_user_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_user_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_user_template.yml
@@ -13,4 +13,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_user_template_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_user_template_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_zone.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_zone.yml
@@ -12,4 +12,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_zone_info.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_zone_info.yml
@@ -10,4 +10,5 @@
 - assert:
     that:
       - result.failed
+      # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'


### PR DESCRIPTION
As the title said you can now add the command_endpoint parameter to your service apply rule to change the host on which the check should be executed on.

updates #107 