### PR TITLE
Improve Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,15 +49,11 @@ jobs:
       # changelog gets updated but action works on old commit id
       - uses: actions/checkout@v2.3.4
         with:
-          fetch-depth: 0
+          ref: master
 
       - name: Generate changelog for the release
-        uses: charmixer/auto-changelog-action@v1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          since_tag: ${{ steps.previoustag.outputs.tag }}
-          future_release: ${{ steps.version.outputs.next-version }}
-          output: CHANGELOGRELEASE.md
+        run: |
+          sed '/## \[${{ steps.previoustag.outputs.tag }}\]/Q' CHANGELOG.md > CHANGELOGRELEASE.md
 
       - name: Read CHANGELOG.md
         id: package


### PR DESCRIPTION
in the past we used to call github-changelog-generator twice. This hav many Problems (API Limit, breaking Workflows)

This change only calls github-changelog-generator once and the workflow should never fail when creating the Release in Github