### PR TITLE
add notification_template to role

### DIFF
--- a/roles/ansible_icinga/README.md
+++ b/roles/ansible_icinga/README.md
@@ -27,161 +27,175 @@ t_systems_mms.icinga_director >= 1.2.2
 
 ## Role Variables
 
-| Variable                   | Required | Default
-|----------------------------|----------|---------
-| **icinga**
-| url                        | yes      |
-| use_proxy                  | no       |
-| validate_certs             | no       |
-| url_username               | yes      |
-| url_password               | yes      |
-| force_basic_auth           | no       |
-| client_cert                | no       |
-| client_key                 | no       |
-| **icinga_timeperiod**
-| icinga_timeperiods         | no       | []
-| display_name               | no       |
-| imports                    | no       |
-| ranges                     | no       |
-| **icinga_user_template**
-| icinga_user_templates      | no       | []
-| imports                    | no       |
-| period                     | no       |
-| enable_notifications       | no       |
-| **icinga_user**
-| icinga_users               | no       | []
-| display_name               | no       |
-| imports                    | yes      | []
-| pager                      | no       |
-| period                     | no       |
-| disabled                   | no       |
-| email                      | yes      | null
-| **icinga_zone**
-| icinga_zones               | no       | []
-| is_global                  | no       |
-| parent                     | no       |
-| **icinga_endpoint**
-| icinga_endpoints           | no       | []
-| host                       | no       |
-| port                       | no       |
-| log_duration               | no       |
-| zone                       | no       |
-| **icinga_hostgroup**
-| icinga_hostgroups          | no       | []
-| display_name               | no       |
-| assign_filter              | no       | `host.name="hostgroup.1-*"`
-| **icinga_host_template**
-| icinga_host_templates      | no       | []
-| display_name               | no       |
-| address                    | no       |
-| address6                   | no       |
-| groups                     | no       |
-| check_command              | no       |
-| check_interval             | no       |
-| disabled                   | no       |
-| imports                    | no       |
-| zone                       | no       |
-| vars                       | no       |
-| notes                      | no       |
-| notes_url                  | no       |
-| **icinga_host**
-| icinga_hosts               | no       | []
-| display_name               | no       |
-| address                    | no       |
-| address6                   | no       |
-| groups                     | no       |
-| disabled                   | no       |
-| imports                    | yes      | []
-| zone                       | no       |
-| vars                       | no       |
-| notes                      | no       |
-| notes_url                  | no       |
-| **icinga_command_template**
-| icinga_command_templates   | no       | []
-| display_name               | no       |
-| command                    | no       |
-| methods_execute            | yes      | PluginCheck
-| timeout                    | no       |
-| imports                    | no       |
-| disabled                   | no       |
-| zone                       | no       |
-| vars                       | no       |
-| arguments                  | no       |
-| **icinga_command**
-| icinga_commands            | no       | []
-| command_type               | yes      | PluginCheck
-| disabled                   | yes      | false
-| imports                    | no       |
-| zone                       | no       |
-| vars                       | no       |
-| **icinga_service**
-| icinga_services            | no       | []
-| display_name               | no       |
-| disabled                   | no       |
-| check_command              | no       |
-| check_interval             | no       |
-| check_period               | no       |
-| check_timeout              | no       |
-| enable_active_checks       | no       |
-| enable_event_handler       | no       |
-| enable_notifications       | no       |
-| enable_passive_checks      | no       |
-| enable_perfdata            | no       |
-| groups                     | no       |
-| host                       | yes      |
-| imports                    | no       |
-| max_check_attempts         | no       |
-| notes                      | no       |
-| notes_url                  | no       |
-| retry_interval             | no       |
-| use_agent                  | no       |
-| vars                       | no       |
-| volatile                   | no       |
-| **icinga_service_template**
-| icinga_service_templates   | no       | []
-| display_name               | no       |
-| disabled                   | no       |
-| check_command              | no       |
-| check_interval             | no       |
-| check_period               | no       |
-| check_timeout              | no       |
-| enable_active_checks       | no       |
-| enable_event_handler       | no       |
-| enable_notifications       | no       |
-| enable_passive_checks      | no       |
-| enable_perfdata            | no       |
-| groups                     | no       |
-| imports                    | no       |
-| max_check_attempts         | no       |
-| notes                      | no       |
-| notes_url                  | no       |
-| retry_interval             | no       |
-| use_agent                  | no       |
-| vars                       | no       |
-| volatile                   | no       |
-| **icinga_service_apply**
-| icinga_service_applys      | no       | []
-| display_name               | no       |
-| groups                     | no       |
-| apply_for                  | no       |
-| assign_filter              | no       |
-| imports                    | no       |
-| vars                       | no       |
-| notes                      | no       |
-| notes_url                  | no       |
-| **icinga_servicegroup**
-| icinga_servicegroups       | no       | []
-| display_name               | no       |
-| assign_filter              | no       |
-| **icinga_notification**
-| icinga_notifications       | no       | []
-| notification_interval      | no       |
-| types                      | no       |
-| users                      | no       |
-| apply_to                   | no       |
-| assign_filter              | no       |
-| imports                    | no       |
-| period                     | no       |
+| Variable                         | Required | Default                     |
+| -------------------------------- | -------- | --------------------------- |
+| **icinga**                       |
+| url                              | yes      |
+| use_proxy                        | no       |
+| validate_certs                   | no       |
+| url_username                     | yes      |
+| url_password                     | yes      |
+| force_basic_auth                 | no       |
+| client_cert                      | no       |
+| client_key                       | no       |
+| **icinga_timeperiod**            |
+| icinga_timeperiods               | no       | []                          |
+| display_name                     | no       |
+| imports                          | no       |
+| ranges                           | no       |
+| **icinga_user_template**         |
+| icinga_user_templates            | no       | []                          |
+| imports                          | no       |
+| period                           | no       |
+| enable_notifications             | no       |
+| **icinga_user**                  |
+| icinga_users                     | no       | []                          |
+| display_name                     | no       |
+| imports                          | yes      | []                          |
+| pager                            | no       |
+| period                           | no       |
+| disabled                         | no       |
+| email                            | yes      | null                        |
+| **icinga_zone**                  |
+| icinga_zones                     | no       | []                          |
+| is_global                        | no       |
+| parent                           | no       |
+| **icinga_endpoint**              |
+| icinga_endpoints                 | no       | []                          |
+| host                             | no       |
+| port                             | no       |
+| log_duration                     | no       |
+| zone                             | no       |
+| **icinga_hostgroup**             |
+| icinga_hostgroups                | no       | []                          |
+| display_name                     | no       |
+| assign_filter                    | no       | `host.name="hostgroup.1-*"` |
+| **icinga_host_template**         |
+| icinga_host_templates            | no       | []                          |
+| display_name                     | no       |
+| address                          | no       |
+| address6                         | no       |
+| groups                           | no       |
+| check_command                    | no       |
+| check_interval                   | no       |
+| disabled                         | no       |
+| imports                          | no       |
+| zone                             | no       |
+| vars                             | no       |
+| notes                            | no       |
+| notes_url                        | no       |
+| **icinga_host**                  |
+| icinga_hosts                     | no       | []                          |
+| display_name                     | no       |
+| address                          | no       |
+| address6                         | no       |
+| groups                           | no       |
+| disabled                         | no       |
+| imports                          | yes      | []                          |
+| zone                             | no       |
+| vars                             | no       |
+| notes                            | no       |
+| notes_url                        | no       |
+| **icinga_command_template**      |
+| icinga_command_templates         | no       | []                          |
+| display_name                     | no       |
+| command                          | no       |
+| methods_execute                  | yes      | PluginCheck                 |
+| timeout                          | no       |
+| imports                          | no       |
+| disabled                         | no       |
+| zone                             | no       |
+| vars                             | no       |
+| arguments                        | no       |
+| **icinga_command**               |
+| icinga_commands                  | no       | []                          |
+| command_type                     | yes      | PluginCheck                 |
+| disabled                         | yes      | false                       |
+| imports                          | no       |
+| zone                             | no       |
+| vars                             | no       |
+| **icinga_service**               |
+| icinga_services                  | no       | []                          |
+| display_name                     | no       |
+| disabled                         | no       |
+| check_command                    | no       |
+| check_interval                   | no       |
+| check_period                     | no       |
+| check_timeout                    | no       |
+| enable_active_checks             | no       |
+| enable_event_handler             | no       |
+| enable_notifications             | no       |
+| enable_passive_checks            | no       |
+| enable_perfdata                  | no       |
+| groups                           | no       |
+| host                             | yes      |
+| imports                          | no       |
+| max_check_attempts               | no       |
+| notes                            | no       |
+| notes_url                        | no       |
+| retry_interval                   | no       |
+| use_agent                        | no       |
+| vars                             | no       |
+| volatile                         | no       |
+| **icinga_service_template**      |
+| icinga_service_templates         | no       | []                          |
+| display_name                     | no       |
+| disabled                         | no       |
+| check_command                    | no       |
+| check_interval                   | no       |
+| check_period                     | no       |
+| check_timeout                    | no       |
+| enable_active_checks             | no       |
+| enable_event_handler             | no       |
+| enable_notifications             | no       |
+| enable_passive_checks            | no       |
+| enable_perfdata                  | no       |
+| groups                           | no       |
+| imports                          | no       |
+| max_check_attempts               | no       |
+| notes                            | no       |
+| notes_url                        | no       |
+| retry_interval                   | no       |
+| use_agent                        | no       |
+| vars                             | no       |
+| volatile                         | no       |
+| **icinga_service_apply**         |
+| icinga_service_applys            | no       | []                          |
+| display_name                     | no       |
+| groups                           | no       |
+| apply_for                        | no       |
+| assign_filter                    | no       |
+| imports                          | no       |
+| vars                             | no       |
+| notes                            | no       |
+| notes_url                        | no       |
+| **icinga_servicegroup**          |
+| icinga_servicegroups             | no       | []                          |
+| display_name                     | no       |
+| assign_filter                    | no       |
+| **icinga_notification_template** |
+| icinga_notification_templates    | no       | []                          |
+| notification_template_object     | no       |
+| state                            | no       |
+| notification_interval            | no       |
+| states                           | no       |
+| types                            | no       |
+| times_begin                      | no       |
+| times_end                        | no       |
+| timeperiod                       | no       |
+| users                            | no       |
+| user_groups                      | no       |
+| notification_command             | no       |
+| imports                          | no       |
+| **icinga_notification**          |
+| icinga_notifications             | no       | []                          |
+| notification_interval            | no       |
+| types                            | no       |
+| users                            | no       |
+| apply_to                         | no       |
+| assign_filter                    | no       |
+| imports                          | no       |
+| period                           | no       |
 
 ## Example Playbook
 

--- a/roles/ansible_icinga/tasks/icinga_notification_template.yml
+++ b/roles/ansible_icinga/tasks/icinga_notification_template.yml
@@ -1,0 +1,30 @@
+---
+# notification_template.1 = notification_template array
+# notification_template.0 = icinga_notification_template attribute
+- name: icinga_notification_template
+  icinga_notification_template:
+    url: "{{ icinga_url }}"
+    use_proxy: "{{ icinga_use_proxy | default(omit) }}"
+    validate_certs: "{{ icinga_validate_certs | default(omit) }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    force_basic_auth: "{{ icinga_force_basic_auth | default(omit) }}"
+    client_cert: "{{ icinga_client_cert | default(omit) }}"
+    client_key: "{{ icinga_client_key | default(omit) }}"
+    object_name: "{{ notification_template.1 }}"
+    state: "{{ notification_template.0.state | default(omit) }}"
+    notification_interval: "{{ notification_template.0.notification_interval | default(omit) }}"
+    states: "{{ notification_template.0.states | default(omit) }}"
+    types: "{{ notification_template.0.types | default(omit) }}"
+    times_begin: "{{ notification_template.0.times_begin | default(omit) }}"
+    times_end: "{{ notification_template.0.times_end | default(omit) }}"
+    time_period: "{{ notification_template.0.time_period | default(omit) }}"
+    users: "{{ notification_template.0.users | default(omit) }}"
+    user_groups: "{{ notification_template.0.user_groups | default(omit) }}"
+    notification_command: "{{ notification_template.0.notification_command | default(omit) }}"
+    imports: "{{ notification_template.0.imports | default(omit) }}"
+
+  loop: "{{ icinga_notification_templates|subelements('notification_template_object') }}"
+  loop_control:
+    loop_var: notification_template
+  tags: notification_template

--- a/roles/ansible_icinga/tasks/main.yml
+++ b/roles/ansible_icinga/tasks/main.yml
@@ -69,6 +69,11 @@
   when: icinga_servicegroups is defined
   tags: servicegroup
 
+- name: icinga notification template configuration
+  include_tasks: icinga_notification_template.yml
+  when: icinga_notification_templates is defined
+  tags: notification_template
+
 - name: icinga notification configuration
   include_tasks: icinga_notification.yml
   when: icinga_notifications is defined


### PR DESCRIPTION
Co-authored-by: Daniel <daniel.xfuture@googlemail.com>

The Code for setting up notification templates was already present but the included role was missing a play to create these from variables. This MR adds this functionality similar to the command_template play.