### PR TITLE
add "vars" variable to icinga_notification in the role

### DIFF
--- a/roles/ansible_icinga/tasks/icinga_notification.yml
+++ b/roles/ansible_icinga/tasks/icinga_notification.yml
@@ -21,6 +21,7 @@
     assign_filter: "{{ notification.0.assign_filter | default(omit) }}"
     imports: "{{ notification.0.imports | default(omit) }}"
     period: "{{ notification.0.period | default(omit) }}"
+    vars: "{{ notification.0.vars | default(omit) }}"
   loop: "{{ icinga_notifications|subelements('notification_object') }}"
   loop_control:
     loop_var: notification


### PR DESCRIPTION
this was missing from the role before and these extra variables are required for some notifications (noticed it when setting up the rocketchat notifications)