### PR TITLE
Add command_endpoint parameter to host and host_template

### DIFF
--- a/examples/icinga_host.yml
+++ b/examples/icinga_host.yml
@@ -22,3 +22,4 @@
     has_agent: true
     master_should_connect: true
     accept_config: true
+    command_endpoint: fooendpoint

--- a/examples/icinga_host_template.yml
+++ b/examples/icinga_host_template.yml
@@ -21,3 +21,4 @@
     master_should_connect: true
     max_check_attempts: 3
     accept_config: true
+    command_endpoint: fooendpoint

--- a/plugins/modules/icinga_host.py
+++ b/plugins/modules/icinga_host.py
@@ -128,6 +128,10 @@ options:
     type: bool
     choices: [True, False]
     version_added: '1.9.0'
+  command_endpoint:
+    description:
+      - The endpoint where commands are executed on.
+    type: str
 """
 
 EXAMPLES = """
@@ -154,6 +158,7 @@ EXAMPLES = """
     has_agent: true
     master_should_connect: true
     accept_config: true
+    command_endpoint: fooendpoint
 """
 
 RETURN = r""" # """
@@ -190,6 +195,7 @@ def main():
         has_agent=dict(type="bool", choices=[True, False]),
         master_should_connect=dict(type="bool", choices=[True, False]),
         accept_config=dict(type="bool", choices=[True, False]),
+        command_endpoint=dict(type="str", required=False),
     )
 
     # When deleting objects, only the name is necessary, so we cannot use
@@ -221,6 +227,7 @@ def main():
         "has_agent": module.params["has_agent"],
         "master_should_connect": module.params["master_should_connect"],
         "accept_config": module.params["accept_config"],
+        "command_endpoint": module.params["command_endpoint"],
     }
 
     icinga_object = Icinga2APIObject(module=module, path="/host", data=data)

--- a/plugins/modules/icinga_host_template.py
+++ b/plugins/modules/icinga_host_template.py
@@ -145,6 +145,10 @@ options:
     type: bool
     choices: [True, False]
     version_added: '1.9.0'
+  command_endpoint:
+    description:
+      - The endpoint where commands are executed on.
+    type: str
 """
 
 EXAMPLES = """
@@ -170,6 +174,7 @@ EXAMPLES = """
     master_should_connect: true
     max_check_attempts: 3
     accept_config: true
+    command_endpoint: fooendpoint
 """
 
 RETURN = r""" # """
@@ -210,6 +215,7 @@ def main():
         max_check_attempts=dict(required=False),
         accept_config=dict(type="bool", choices=[True, False]),
         event_command=dict(type="str", required=False),
+        command_endpoint=dict(type="str", required=False),
     )
 
     # Define the main module
@@ -238,6 +244,7 @@ def main():
         "max_check_attempts": module.params["max_check_attempts"],
         "accept_config": module.params["accept_config"],
         "event_command": module.params["event_command"],
+        "command_endpoint": module.params["command_endpoint"],
     }
 
     icinga_object = Icinga2APIObject(module=module, path="/host", data=data)

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_host.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_host.yml
@@ -20,3 +20,4 @@
     has_agent: true
     master_should_connect: true
     accept_config: true
+    command_endpoint: fooendpoint

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_host_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_host_template.yml
@@ -19,3 +19,4 @@
     master_should_connect: true
     max_check_attempts: 3
     accept_config: true
+    command_endpoint: fooendpoint

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_host.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_host.yml
@@ -22,3 +22,4 @@
     has_agent: true
     master_should_connect: true
     accept_config: true
+    command_endpoint: fooendpoint

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_host_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_host_template.yml
@@ -21,3 +21,4 @@
     master_should_connect: true
     max_check_attempts: 3
     accept_config: true
+    command_endpoint: fooendpoint

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_host.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_host.yml
@@ -22,6 +22,7 @@
     has_agent: true
     master_should_connect: true
     accept_config: true
+    command_endpoint: fooendpoint
   ignore_errors: true
   register: result
 - assert:

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_host_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_host_template.yml
@@ -21,6 +21,7 @@
     master_should_connect: true
     max_check_attempts: 3
     accept_config: true
+    command_endpoint: fooendpoint
   ignore_errors: true
   register: result
 - assert:

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_host.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_host.yml
@@ -22,6 +22,7 @@
     has_agent: true
     master_should_connect: true
     accept_config: true
+    command_endpoint: fooendpoint
   ignore_errors: true
   register: result
 - assert:

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_host_template.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_host_template.yml
@@ -21,6 +21,7 @@
     master_should_connect: true
     max_check_attempts: 3
     accept_config: true
+    command_endpoint: fooendpoint
   ignore_errors: true
   register: result
 - assert:


### PR DESCRIPTION
Hi,

this PR adds the 'command_endpoint' parameter to the host and host_template modules. I also added them to examples and tests. I would appriciate having this change upstream as we use it to deploy our host checks to the respective Icinga2 satellites.

BR
Jens Rudolf