### PR TITLE
improve autogenerated documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - master
 
+env:
+  NAMESPACE: t_systems_mms
+  COLLECTION_NAME: icinga_director
+  ANSIBLE_COLLECTIONS_PATHS: ./
+
 jobs:
   update_docs:
     runs-on: ubuntu-latest
@@ -14,6 +19,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
         with:
+          fetch-depth: 0
+
+      # ansible-doc-extractor requires the collection to be in a directory in
+      # the form ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}/
+
+      - name: Check out code to ansible collection location
+        uses: actions/checkout@v2.3.4
+        with:
+          path: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
           fetch-depth: 0
 
       - name: Set up Python


### PR DESCRIPTION
The current workflow works, because our collection is included in Ansible by default and `ansible-doc-extracor` resolves all doc_fragments in the distributed collection. We should use the doc_fragemnts from our current release to avoid inconsistencies.