### PR TITLE
add resolve option to inventory-plugin

### DIFF
--- a/plugins/inventory/icinga_director_inventory.py
+++ b/plugins/inventory/icinga_director_inventory.py
@@ -94,7 +94,7 @@ class InventoryModule(BaseInventoryPlugin):
             self.url,
             self.url_username,
             self.url_password,
-            url_path="/director/hosts",
+            url_path="/director/hosts" + "?resolved",
         )
 
         for host in host_list["objects"]:


### PR DESCRIPTION
this allows us to query host_vars with the inventory-plugin:

```
> ansible -i inventory.icinga_director_inventory.yaml host-test-web01 -m debug -a "var=hostvars[inventory_hostname]['vars']['HostOS']"

host-test-web01 | SUCCESS => {
    "hostvars[inventory_hostname]['vars']['HostOS']": "Linux"
}
```