### PR TITLE
fix call url function

### DIFF
--- a/plugins/module_utils/icinga.py
+++ b/plugins/module_utils/icinga.py
@@ -54,16 +54,28 @@ class Icinga2APIObject(object):
         )
         content = ""
         error = ""
-        if rsp:
-            content = json.loads(rsp.read().decode("utf-8"))
+
+        # handle 400 errors
         if info["status"] >= 400:
             try:
                 content = json.loads(info["body"].decode("utf-8"))
                 error = content["error"]
             except (ValueError, KeyError):
                 error = info["msg"]
-        if info["status"] < 0:
+
+        # handle other errors
+        elif info["status"] < 0:
             error = info["msg"]
+
+        # if nothing is modified when trying to change objects, fetch_url
+        # returns only the 304 status but no body.
+	# if that happens we set the content to an empty json object.
+        # else we serialize the response as a json object.
+        elif info["status"] == 304:
+            content = {}
+        else:
+            content = json.loads(rsp.read().decode("utf-8"))
+
         return {"code": info["status"], "data": content, "error": error}
 
     def exists(self, find_by="name"):

--- a/plugins/module_utils/icinga.py
+++ b/plugins/module_utils/icinga.py
@@ -69,7 +69,7 @@ class Icinga2APIObject(object):
 
         # if nothing is modified when trying to change objects, fetch_url
         # returns only the 304 status but no body.
-	# if that happens we set the content to an empty json object.
+        # if that happens we set the content to an empty json object.
         # else we serialize the response as a json object.
         elif info["status"] == 304:
             content = {}


### PR DESCRIPTION
there was a recent commit ([4073a22d5599bdf05589b91428ad6e16d7b6640d](https://github.com/ansible/ansible/commit/4073a22d5599bdf05589b91428ad6e16d7b6640d)) that
changed what's returned in case of an http-error. Before, the response-body
was returned, after this change, only the return-code was returned.
(which is correct btw, according to rfc 2616: "The 304 response MUST NOT contain a
   message-body, and thus is always terminated by the first empty line
   after the header fields.")

Now we check if the response code is a 304 and set the response body to empty.