### PR TITLE
role: add check_command to icinga_service_apply

### DIFF
--- a/roles/ansible_icinga/tasks/icinga_service_apply.yml
+++ b/roles/ansible_icinga/tasks/icinga_service_apply.yml
@@ -25,6 +25,7 @@
     check_interval: "{{ service_apply.0.check_interval | default(omit) }}"
     check_period: "{{ service_apply.0.check_period | default(omit) }}"
     check_timeout: "{{ service_apply.0.check_timeout | default(omit) }}"
+    check_command: "{{ service_apply.0.check_command | default(omit) }}"
     enable_active_checks: "{{ service_apply.0.enable_active_checks | default(omit) }}"
     enable_event_handler: "{{ service_apply.0.enable_event_handler | default(omit) }}"
     enable_notifications: "{{ service_apply.0.enable_notifications | default(omit) }}"


### PR DESCRIPTION
add the 'check_command' parameter to the 'icinga_service_apply' task.

This should be working according to the examples but is currently missing here which leads to the following error message:

```
Error: Validation failed for object 'service_apply_rule' of type 'Service'; Attribute 'check_command': Attribute must not be empty.
```