### PR TITLE
Add icinga_serviceset module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Additionally all supported modules have an appropriate `*_info`-module to gather
     * `icinga_service_apply`
     * `icinga_service_template`
     * `icinga_servicegroup`
+    * `icinga_serviceset`
     * `icinga_timeperiod`
     * `icinga_timeperiod_template`
     * `icinga_user_group`

--- a/docs/icinga_service.rst
+++ b/docs/icinga_service.rst
@@ -80,9 +80,15 @@ Parameters
     Service groups can be directly assigned to single services or to service templates.
 
 
-  host (True, str, None)
+  host (optional, str, None)
     Choose the host this single service should be assigned to.
 
+    If ``service_set`` is not provided this property is required.
+
+  service_set (optional, str, None)
+    Choose the serviceset this single service should be assigned to.
+
+    If ``host`` is not provided this property is required.
 
   imports (optional, list, [])
     Importable templates, add as many as you want.
@@ -213,7 +219,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
+
     - name: Create service
       tags: service
       t_systems_mms.icinga_director.icinga_service:
@@ -245,6 +251,14 @@ Examples
         notes_url: "'http://url1' 'http://url2'"
         append: true
 
+    - name: Create serviceset service
+      t_systems_mms.icinga_director.icinga_service:
+        state: present
+        url: "{{ icinga_url }}"
+        url_username: "{{ icinga_user }}"
+        url_password: "{{ icinga_pass }}"
+        object_name: "foo service serviceset"
+        service_set: "foo_serviceset"
 
 
 

--- a/docs/icinga_serviceset.rst
+++ b/docs/icinga_serviceset.rst
@@ -1,0 +1,166 @@
+.. _icinga_serviceset_module:
+
+
+icinga_serviceset -- Manage servicesets in Icinga2
+============================================
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+
+Add or remove a serviceset to Icinga2 through the director API.
+
+
+
+
+
+
+Parameters
+----------
+
+  state (optional, str, present)
+    Apply feature state.
+
+
+  assign_filter (optional, str, None)
+    This allows you to configure an assignment filter.
+
+    Please feel free to combine as many nested operators as you want.
+
+
+  object_name (True, str, None)
+    Name of the service.
+
+
+  description (optional, str, None)
+    A meaningful description explaining your users what to expect when assigning this set of services.
+
+
+  append (optional, bool, None)
+    Do not overwrite the whole object but instead append the defined properties.
+
+    Note - Appending to existing vars, imports or any other list/dict is not possible. You have to overwrite the complete list/dict.
+
+    Note - Variables that are set by default will also be applied, even if not set.
+
+
+  url (True, str, None)
+    HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+
+
+  force (optional, bool, False)
+    If ``yes`` do not get a cached copy.
+
+    Alias ``thirsty`` has been deprecated and will be removed in 2.13.
+
+
+  http_agent (optional, str, ansible-httpget)
+    Header to identify as, generally appears in web server logs.
+
+
+  use_proxy (optional, bool, True)
+    If ``no``, it will not use a proxy, even if one is defined in an environment variable on the target hosts.
+
+
+  validate_certs (optional, bool, True)
+    If ``no``, SSL certificates will not be validated.
+
+    This should only be used on personally controlled sites using self-signed certificates.
+
+
+  url_username (optional, str, None)
+    The username for use in HTTP basic authentication.
+
+    This parameter can be used without *url_password* for sites that allow empty passwords
+
+
+  url_password (optional, str, None)
+    The password for use in HTTP basic authentication.
+
+    If the *url_username* parameter is not specified, the *url_password* parameter will not be used.
+
+
+  force_basic_auth (optional, bool, False)
+    Credentials specified with *url_username* and *url_password* should be passed in HTTP Header.
+
+
+  client_cert (optional, path, None)
+    PEM formatted certificate chain file to be used for SSL client authentication.
+
+    This file can also include the key as well, and if the key is included, ``client_key`` is not required.
+
+
+  client_key (optional, path, None)
+    PEM formatted file that contains your private key to be used for SSL client authentication.
+
+    If ``client_cert`` contains both the certificate and key, this option is not required.
+
+
+  use_gssapi (optional, bool, False)
+    Use GSSAPI to perform the authentication, typically this is for Kerberos or Kerberos through Negotiate authentication.
+
+    Requires the Python library `gssapi <https://github.com/pythongssapi/python-gssapi>`_ to be installed.
+
+    Credentials for GSSAPI can be specified with *url_username*/*url_password* or with the GSSAPI env var ``KRB5CCNAME`` that specified a custom Kerberos credential cache.
+
+    NTLM authentication is ``not`` supported even if the GSSAPI mech for NTLM has been installed.
+
+
+
+
+
+
+Notes
+-----
+
+.. note::
+   - This module supports check mode.
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+
+    - name: Create serviceset
+    t_systems_mms.icinga_director.icinga_serviceset:
+        state: present
+        url: "{{ icinga_url }}"
+        url_username: "{{ icinga_user }}"
+        url_password: "{{ icinga_pass }}"
+        object_name: "foo_serviceset"
+        assign_filter: 'host.name="foohost"'
+        description: "foo description"
+
+    - name: Update serviceset
+    t_systems_mms.icinga_director.icinga_serviceset:
+        state: present
+        url: "{{ icinga_url }}"
+        url_username: "{{ icinga_user }}"
+        url_password: "{{ icinga_pass }}"
+        object_name: "foo_serviceset"
+        assign_filter: 'host.name="foohost2"'
+        append: true
+
+
+
+
+Status
+------
+
+
+
+
+
+Authors
+~~~~~~~
+
+- Heiko Neblung (@HeikoNeblung)
+

--- a/docs/icinga_serviceset.rst
+++ b/docs/icinga_serviceset.rst
@@ -2,7 +2,7 @@
 
 
 icinga_serviceset -- Manage servicesets in Icinga2
-============================================
+==================================================
 
 .. contents::
    :local:

--- a/examples/icinga_service.yml
+++ b/examples/icinga_service.yml
@@ -28,3 +28,11 @@
     notes: "example note"
     notes_url: "'http://url1' 'http://url2'"
     append: true
+- name: Create serviceset service
+  t_systems_mms.icinga_director.icinga_service:
+    state: present
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "foo service serviceset"
+    service_set: "foo_serviceset"

--- a/examples/icinga_serviceset.yml
+++ b/examples/icinga_serviceset.yml
@@ -1,0 +1,19 @@
+---
+- name: Create serviceset
+  t_systems_mms.icinga_director.icinga_serviceset:
+    state: present
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "foo_serviceset"
+    assign_filter: 'host.name="foohost"'
+    description: "foo description"
+- name: Update serviceset
+  t_systems_mms.icinga_director.icinga_serviceset:
+    state: present
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "foo_serviceset"
+    assign_filter: 'host.name="foohost2"'
+    append: true

--- a/plugins/modules/icinga_service.py
+++ b/plugins/modules/icinga_service.py
@@ -99,7 +99,8 @@ options:
   host:
     description:
       - Choose the host this single service should be assigned to.
-    required: true
+      - This field will be required when `service_set` is not defined.
+    required: false
     type: "str"
   imports:
     description:
@@ -158,8 +159,9 @@ options:
   service_set:
     description:
       - Choose the service set name this single service should be assigned to.
+      - This field will be required when `host` is not defined.
     type: str
-    version_added: ''
+    version_added: '1.29.0'
 """
 
 EXAMPLES = """

--- a/plugins/modules/icinga_service.py
+++ b/plugins/modules/icinga_service.py
@@ -372,6 +372,19 @@ def main():
 
     data["object_type"] = "object"
 
+    # Only one of "service_set" or "host" needs to be present at the
+    # same time so we cannot use required=True in the argument_spec.
+    # Instead we define here that only one of the two parameters is defined at the same time.
+    if (
+        module.params["state"] == "present"
+        and not module.params["append"]
+        and module.params["host"]
+        and module.params["service_set"]
+    ):
+        module.fail_json(
+            msg="Only one of the properties host or service_set can be defined within the same object."
+        )
+
     icinga_object = IcingaServiceObject(
         module=module, path="/service", data=data
     )

--- a/plugins/modules/icinga_service.py
+++ b/plugins/modules/icinga_service.py
@@ -385,6 +385,16 @@ def main():
             msg="Only one of the properties host or service_set can be defined within the same object."
         )
 
+    if (
+        module.params["state"] == "present"
+        and not module.params["append"]
+        and not module.params["host"]
+        and not module.params["service_set"]
+    ):
+        module.fail_json(
+            msg="One of the properties host or service_set is required."
+        )
+
     icinga_object = IcingaServiceObject(
         module=module, path="/service", data=data
     )

--- a/plugins/modules/icinga_serviceset.py
+++ b/plugins/modules/icinga_serviceset.py
@@ -1,0 +1,151 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020 T-Systems Multimedia Solutions GmbH
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: icinga_serviceset
+short_description: Manage servicesets in Icinga2
+description:
+   - Add or remove a serviceset to Icinga2 through the director API.
+author: Heiko Neblung (@HeikoNeblung)
+extends_documentation_fragment:
+  - ansible.builtin.url
+  - t_systems_mms.icinga_director.common_options
+version_added: ''
+notes:
+  - This module supports check mode.
+options:
+  append:
+    description:
+      - Do not overwrite the whole object but instead append the defined properties.
+      - Note - Appending to existing vars, imports or any other list/dict is not possible. You have to overwrite the complete list/dict.
+      - Note - Variables that are set by default will also be applied, even if not set.
+    type: bool
+    choices: [True, False]
+  assign_filter:
+    description:
+      - This allows you to configure an assignment filter.
+      - Please feel free to combine as many nested operators as you want.
+    type: str
+  description:
+    description:
+      - A meaningful description explaining your users what to expect when assigning this set of services.
+    type: str
+  object_name:
+    description:
+      - Icinga object name for this serviceset.
+    aliases: ['name']
+    required: true
+    type: str
+  state:
+    description:
+      - Apply feature state.
+    choices: [ "present", "absent" ]
+    default: present
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create serviceset
+  t_systems_mms.icinga_director.icinga_serviceset:
+    state: present
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "foo_serviceset"
+    assign_filter: 'host.name="foohost"'
+    description: "foo description"
+
+- name: Update serviceset
+  t_systems_mms.icinga_director.icinga_serviceset:
+    state: present
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "foo_serviceset"
+    assign_filter: 'host.name="foohost2"'
+    append: true
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import url_argument_spec
+from ansible_collections.t_systems_mms.icinga_director.plugins.module_utils.icinga import (
+    Icinga2APIObject,
+)
+
+
+# ===========================================
+# Module execution.
+#
+def main():
+    # use the predefined argument spec for url
+    argument_spec = url_argument_spec()
+    # add our own arguments
+    argument_spec.update(
+        append=dict(type="bool", choices=[True, False]),
+        assign_filter=dict(required=False),
+        description=dict(required=False),
+        object_name=dict(required=True, aliases=["name"]),
+        state=dict(default="present", choices=["absent", "present"]),
+        url=dict(required=True),
+    )
+
+    # Define the main module
+    module = AnsibleModule(
+        argument_spec=argument_spec, supports_check_mode=True
+    )
+
+    data_keys = [
+        "assign_filter",
+        "description",
+        "object_name",
+    ]
+
+    data = {}
+
+    if module.params["append"]:
+        for k in data_keys:
+            if module.params[k]:
+                data[k] = module.params[k]
+    else:
+        for k in data_keys:
+            data[k] = module.params[k]
+
+    data["object_type"] = "template"
+
+    icinga_object = Icinga2APIObject(
+        module=module, path="/serviceSet", data=data
+    )
+
+    changed, diff = icinga_object.update(module.params["state"])
+    module.exit_json(
+        changed=changed,
+        diff=diff,
+    )
+
+
+# import module snippets
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/icinga_serviceset.py
+++ b/plugins/modules/icinga_serviceset.py
@@ -31,7 +31,7 @@ author: Heiko Neblung (@HeikoNeblung)
 extends_documentation_fragment:
   - ansible.builtin.url
   - t_systems_mms.icinga_director.common_options
-version_added: ''
+version_added: '1.29.0'
 notes:
   - This module supports check mode.
 options:

--- a/roles/ansible_icinga/defaults/main.yml
+++ b/roles/ansible_icinga/defaults/main.yml
@@ -39,6 +39,9 @@ icinga_command_disabled: false
 # icinga_service
 icinga_services: []
 
+# icinga_serviceset
+icinga_servicesets: []
+
 # icinga_service_template
 icinga_service_templates: []
 

--- a/roles/ansible_icinga/tasks/icinga_serviceset.yml
+++ b/roles/ansible_icinga/tasks/icinga_serviceset.yml
@@ -1,0 +1,25 @@
+---
+# serviceset.1 = serviceset array
+# serviceset.0 = icinga_serviceset attribute
+- name: icinga_serviceset
+  icinga_serviceset:
+    url: "{{ icinga_url }}"
+    use_proxy: "{{ icinga_use_proxy | default(omit) }}"
+    validate_certs: "{{ icinga_validate_certs | default(omit) }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    force_basic_auth: "{{ icinga_force_basic_auth | default(omit) }}"
+    client_cert: "{{ icinga_client_cert | default(omit) }}"
+    client_key: "{{ icinga_client_key | default(omit) }}"
+    state: "{{ service.0.state | default(omit) }}"
+    assign_filter: "{{ serviceset.0.assign_filter | default(omit)}}"
+    description: "{{ serviceset.0.description | default(omit)}}"
+    object_name: "{{ serviceset.1 }}"
+  retries: 3
+  delay: 3
+  register: result
+  until: result is succeeded
+  loop: "{{ icinga_servicesets|subelements('serviceset_object') }}"
+  loop_control:
+    loop_var: serviceset
+  tags: serviceset

--- a/roles/ansible_icinga/tasks/main.yml
+++ b/roles/ansible_icinga/tasks/main.yml
@@ -69,6 +69,11 @@
   when: icinga_services is defined
   tags: service
 
+- name: icinga serviceset configuration
+  include_tasks: icinga_serviceset.yml
+  when: icinga_servicesets is defined
+  tags: serviceset
+
 - name: icinga notification template configuration
   include_tasks: icinga_notification_template.yml
   when: icinga_notification_templates is defined

--- a/tests/integration/targets/icinga/checkmode.yml
+++ b/tests/integration/targets/icinga/checkmode.yml
@@ -42,6 +42,7 @@
         - icinga_hostgroup.yml
         - icinga_host_template.yml
         - icinga_host.yml
+        - icinga_serviceset.yml
         - icinga_service.yml
 
         - absent_icinga_host.yml
@@ -62,3 +63,4 @@
         - absent_icinga_endpoint.yml
         - absent_icinga_zone.yml
         - absent_icinga_service.yml
+        - absent_icinga_serviceset.yml

--- a/tests/integration/targets/icinga/checkmode_2.yml
+++ b/tests/integration/targets/icinga/checkmode_2.yml
@@ -23,6 +23,7 @@
         - icinga_hostgroup.yml
         - icinga_host_template.yml
         - icinga_host.yml
+        - icinga_serviceset.yml
         - icinga_service.yml
 
         - absent_icinga_host.yml
@@ -43,6 +44,7 @@
         - absent_icinga_endpoint.yml
         - absent_icinga_zone.yml
         - absent_icinga_service.yml
+        - absent_icinga_serviceset.yml
 
         - icinga_zone.yml
         - icinga_endpoint.yml
@@ -61,4 +63,5 @@
         - icinga_hostgroup.yml
         - icinga_host_template.yml
         - icinga_host.yml
+        - icinga_serviceset.yml
         - icinga_service.yml

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_service.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_service.yml
@@ -28,3 +28,11 @@
     notes: "example note"
     notes_url: "'http://url1' 'http://url2'"
     append: true
+- name: Create serviceset service
+  t_systems_mms.icinga_director.icinga_service:
+    state: absent
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "foo service serviceset"
+    service_set: "foo_serviceset"

--- a/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_serviceset.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/absent_icinga_serviceset.yml
@@ -1,0 +1,19 @@
+---
+- name: Create serviceset
+  t_systems_mms.icinga_director.icinga_serviceset:
+    state: absent
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "foo_serviceset"
+    assign_filter: 'host.name="foohost"'
+    description: "foo description"
+- name: Update serviceset
+  t_systems_mms.icinga_director.icinga_serviceset:
+    state: absent
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "foo_serviceset"
+    assign_filter: 'host.name="foohost2"'
+    append: true

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_service.yml
@@ -28,3 +28,11 @@
     notes: "example note"
     notes_url: "'http://url1' 'http://url2'"
     append: true
+- name: Create serviceset service
+  t_systems_mms.icinga_director.icinga_service:
+    state: present
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "foo service serviceset"
+    service_set: "foo_serviceset"

--- a/tests/integration/targets/icinga/roles/icinga/tasks/icinga_serviceset.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/icinga_serviceset.yml
@@ -1,0 +1,19 @@
+---
+- name: Create serviceset
+  t_systems_mms.icinga_director.icinga_serviceset:
+    state: present
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "foo_serviceset"
+    assign_filter: 'host.name="foohost"'
+    description: "foo description"
+- name: Update serviceset
+  t_systems_mms.icinga_director.icinga_serviceset:
+    state: present
+    url: "{{ icinga_url }}"
+    url_username: "{{ icinga_user }}"
+    url_password: "{{ icinga_pass }}"
+    object_name: "foo_serviceset"
+    assign_filter: 'host.name="foohost2"'
+    append: true

--- a/tests/integration/targets/icinga/roles/icinga/tasks/main.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/main.yml
@@ -19,6 +19,7 @@
     - icinga_hostgroup.yml
     - icinga_host_template.yml
     - icinga_host.yml
+    - icinga_serviceset.yml
     - icinga_service.yml
     - icinga_scheduled_downtime.yml
 
@@ -54,6 +55,7 @@
     - icinga_hostgroup.yml
     - icinga_host_template.yml
     - icinga_host.yml
+    - icinga_serviceset.yml
     - icinga_service.yml
     - icinga_scheduled_downtime.yml
 
@@ -116,6 +118,7 @@
     - wrong_host_icinga_hostgroup.yml
     - wrong_host_icinga_host_template.yml
     - wrong_host_icinga_host.yml
+    - wrong_host_icinga_serviceset.yml
     - wrong_host_icinga_service.yml
     - wrong_host_icinga_scheduled_downtime.yml
 
@@ -137,6 +140,7 @@
     - wrong_pass_icinga_hostgroup.yml
     - wrong_pass_icinga_host_template.yml
     - wrong_pass_icinga_host.yml
+    - wrong_pass_icinga_serviceset.yml
     - wrong_pass_icinga_service.yml
     - wrong_pass_icinga_scheduled_downtime.yml
 
@@ -200,6 +204,7 @@
     - absent_icinga_timeperiod_template.yml
     - absent_icinga_command.yml
     - absent_icinga_command_template.yml
+    - absent_icinga_serviceset.yml
 
 - name: deploy changes in icinga
   tags: uri

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_serviceset.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_host_icinga_serviceset.yml
@@ -1,20 +1,13 @@
 ---
-- name: Create service
-  tags: service
-  t_systems_mms.icinga_director.icinga_service:
+- name: Create serviceset
+  t_systems_mms.icinga_director.icinga_serviceset:
     state: present
     url: http://nonexistant
     url_username: "{{ icinga_user }}"
     url_password: "{{ icinga_pass }}"
-    object_name: "foo service"
-    display_name: "foo service"
-    check_command: hostalive
-    use_agent: false
-    host: foohost
-    vars:
-      procs_argument: consul
-      procs_critical: '1:'
-      procs_warning: '1:'
+    object_name: "foo_serviceset"
+    assign_filter: 'host.name="foohost"'
+    description: "foo description"
   ignore_errors: true
   register: result
 - assert:
@@ -22,34 +15,15 @@
       - result.failed
       # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
-- name: Update service
-  tags: service
-  t_systems_mms.icinga_director.icinga_service:
+- name: Update serviceset
+  t_systems_mms.icinga_director.icinga_serviceset:
     state: present
     url: http://nonexistant
     url_username: "{{ icinga_user }}"
     url_password: "{{ icinga_pass }}"
-    object_name: "foo service"
-    display_name: "foo service"
-    host: foohost
-    notes: "example note"
-    notes_url: "'http://url1' 'http://url2'"
+    object_name: "foo_serviceset"
+    assign_filter: 'host.name="foohost2"'
     append: true
-  ignore_errors: true
-  register: result
-- assert:
-    that:
-      - result.failed
-      # yamllint disable-line rule:line-length
-      - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
-- name: Create serviceset service
-  t_systems_mms.icinga_director.icinga_service:
-    state: present
-    url: http://nonexistant
-    url_username: "{{ icinga_user }}"
-    url_password: "{{ icinga_pass }}"
-    object_name: "foo service serviceset"
-    service_set: "foo_serviceset"
   ignore_errors: true
   register: result
 - assert:

--- a/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_serviceset.yml
+++ b/tests/integration/targets/icinga/roles/icinga/tasks/wrong_pass_icinga_serviceset.yml
@@ -1,20 +1,13 @@
 ---
-- name: Create service
-  tags: service
-  t_systems_mms.icinga_director.icinga_service:
+- name: Create serviceset
+  t_systems_mms.icinga_director.icinga_serviceset:
     state: present
     url: "{{ icinga_url }}"
     url_username: "{{ icinga_user }}"
     url_password: iamwrong
-    object_name: "foo service"
-    display_name: "foo service"
-    check_command: hostalive
-    use_agent: false
-    host: foohost
-    vars:
-      procs_argument: consul
-      procs_critical: '1:'
-      procs_warning: '1:'
+    object_name: "foo_serviceset"
+    assign_filter: 'host.name="foohost"'
+    description: "foo description"
   ignore_errors: true
   register: result
 - assert:
@@ -22,34 +15,15 @@
       - result.failed
       # yamllint disable-line rule:line-length
       - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
-- name: Update service
-  tags: service
-  t_systems_mms.icinga_director.icinga_service:
+- name: Update serviceset
+  t_systems_mms.icinga_director.icinga_serviceset:
     state: present
     url: "{{ icinga_url }}"
     url_username: "{{ icinga_user }}"
     url_password: iamwrong
-    object_name: "foo service"
-    display_name: "foo service"
-    host: foohost
-    notes: "example note"
-    notes_url: "'http://url1' 'http://url2'"
+    object_name: "foo_serviceset"
+    assign_filter: 'host.name="foohost2"'
     append: true
-  ignore_errors: true
-  register: result
-- assert:
-    that:
-      - result.failed
-      # yamllint disable-line rule:line-length
-      - 'result.msg in [ "bad return code while creating: 401. Error message: HTTP Error 401: Unauthorized", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>", "bad return code while creating: -1. Error message: Request failed: <urlopen error [Errno -2] Name or service not known>", "bad return code while querying: 401. Error message: HTTP Error 401: Unauthorized", ]'
-- name: Create serviceset service
-  t_systems_mms.icinga_director.icinga_service:
-    state: present
-    url: "{{ icinga_url }}"
-    url_username: "{{ icinga_user }}"
-    url_password: iamwrong
-    object_name: "foo service serviceset"
-    service_set: "foo_serviceset"
   ignore_errors: true
   register: result
 - assert:


### PR DESCRIPTION
Added service sets module (see #87)

Added support for service sets in `icinga_service` module.

I was unable to provide a icinga_serviceset_info module since there is a potential bug in director restapi which does not return any content for endpoint /services/sets

BTW: Is there a desired way to handle the `version_added` property in docstrings?