### PR TITLE
Add action_group to enable module default groups

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,43 @@
 ---
 requires_ansible: '>=2.9.10'
+
+action_groups:
+  icinga:
+    - icinga_command
+    - icinga_command_info
+    - icinga_command_template
+    - icinga_command_template_info
+    - icinga_endpoint
+    - icinga_endpoint_info
+    - icinga_host
+    - icinga_host_info
+    - icinga_host_template
+    - icinga_host_template_info
+    - icinga_hostgroup
+    - icinga_hostgroup_info
+    - icinga_notification
+    - icinga_notification_info
+    - icinga_notification_template
+    - icinga_notification_template_info
+    - icinga_scheduled_downtime
+    - icinga_service
+    - icinga_service_apply
+    - icinga_service_apply_info
+    - icinga_service_info
+    - icinga_service_template
+    - icinga_service_template_info
+    - icinga_servicegroup
+    - icinga_servicegroup_info
+    - icinga_serviceset
+    - icinga_timeperiod
+    - icinga_timeperiod_info
+    - icinga_timeperiod_template
+    - icinga_timeperiod_template_info
+    - icinga_user
+    - icinga_user_group
+    - icinga_user_group_info
+    - icinga_user_info
+    - icinga_user_template
+    - icinga_user_template_info
+    - icinga_zone
+    - icinga_zone_info


### PR DESCRIPTION
This is to support a feature provided by ansible-core >= 2.12 that enables providing default values for a group of modules instead of each module seperately. See https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html#module-defaults-groups for more details.